### PR TITLE
Update Msg_5732_SystemDiscovery.js

### DIFF
--- a/payload/Msg_5732_SystemDiscovery.js
+++ b/payload/Msg_5732_SystemDiscovery.js
@@ -13,7 +13,7 @@
 	{
 		var status = new Parser()
 		.skip(8)
-		.string('SystemCode', 	{ encoding: 'ascii', length: 8 })
+		.string('SystemCode', 	{ encoding: 'ascii', length: 8, stripNull: true })
 		.int16le('SystemFirmwareVersion')
 		.int16le('SystemHardwareVersion')
 		.int32le('SystemTime') // Epoch


### PR DESCRIPTION
SystemCode is a fixed-length string of 8 characters. If the system name is less than 8 characters, it is appending \u0000 (null) characters. This fix cleans up the nulls.