### PR TITLE
Reduce MQTT Traffic by Discarding Messages

### DIFF
--- a/config.json_dist
+++ b/config.json_dist
@@ -3,6 +3,7 @@
 		"mqtthost" : "localhost",
 		"mqttusername" : "mqtt",
 		"mqttpassword" : "mqtt",
+		"timeoutinseconds" : -1,
 		"influxhost" : "localhost",
 		"influxdatabase" : "batrium"
 	},

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "mqtt": "latest",
     "binary-parser": "latest",
-    "influx": "latest"
+    "influx": "latest",
+    "moment": "latest"
   }
 }


### PR DESCRIPTION
Adds moment.js as a require.
MQTT messages are feeding a home automation system and it doesn't need to be millisecond-accurate. This change reduces the number of updates through MQTT. It assumes a single message being monitored. Default should be no delay, but my node skills aren't that great. :)