### PR TITLE
Optimize parsing: construct parsers only once

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,25 +51,15 @@ const influx = new Influx.InfluxDB({
 // Function to get payload data
 // input data object
 // output payload data in json form
+const payloadParser = new Parser()
+	.string('first', { encoding: 'ascii', length: 1 })
+	.int16le('MessageId', { formatter: (x) => {return x.toString(16);}})
+	.string('nd', { encoding: 'ascii', length: 1 })
+	.int16le('SystemId')
+	.int16le('hubId');
 function getPayload(data) {
-     var payload = new Parser()
-         .string('first', { encoding: 'ascii', length: 1 })
-         .int16le('MessageId', { formatter: (x) => {return x.toString(16);}})
-         .string('nd', { encoding: 'ascii', length: 1 })
-         .int16le('SystemId')
-         .int16le('hubId')
-	
-	 return payload.parse(data);
+	 return payloadParser.parse(data);
 }
-
-function getArrayObject(msg) {
-
-	obj = Object.assign(payload, eval(messages[payload.MessageId])(msg))
-	
-		
-	return obj;
-}
-
 
 
 

--- a/payload/Msg_3e32_StatusRapid.js
+++ b/payload/Msg_3e32_StatusRapid.js
@@ -1,50 +1,47 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Aggregated telemetry
-	// Object      = Rapid
-	// Description = Combined status - Rapid
-	// MsgLength   = 50
-	// Version     = 2
-	// Frequency   = 300 mS
-	// Support     = Current
-	// Valid from  = SW 1.0.30
-	this.parse_3e32 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.int16le('MinCellVolt',		{ formatter: (x) => {return x/1000;}})
-		.int16le('MaxCellVolt',		{ formatter: (x) => {return x/1000;}})
-		.uint8('MinCellVoltId')
-		.uint8('MaxCellVoltId')
-		.uint8('MinCellTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('MaxCellTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('MinCellTempId')
-		.uint8('MaxCellTempId')
-		.int16le('MinBypassAmp', 	{ formatter: (x) => {return x/1000;}})
-		.int16le('MaxBypassAmp', 	{ formatter: (x) => {return x/1000;}})
-		.uint8('MinBypassAmpId')
-		.uint8('MaxBypassAmpId')
-		.uint8('MinBypassTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('MaxBypassTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('MinBypassTempId',	{ formatter: (x) => {return x-40;}})
-		.uint8('MaxBypassTempId',	{ formatter: (x) => {return x-40;}})
-		.int16le('AvgCellVolt',   	{ formatter: (x) => {return x/1000;}})
-		.uint8('AvgCellTemp',    	{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('NumOfCellsAboveInitialBypass')
-		.uint8('NumOfCellsAboveFinalBypass')
-		.uint8('NumOfCellsInBypass')
-		.uint8('NumOfCellsOverdue')
-		.uint8('NumOfCellsActive')
-		.uint8('NumOfCellsInSystem')
-		.uint8('CmuTxOpStatusId')
-		.uint8('CmuRxOpStatusId')
-		.uint8('CmuRxOpStatusUSN')
-		.int16le('ShuntVoltage',	{ formatter: (x) => {return x/100;}})  // voltage
-		.floatle('ShuntCurrent',	{ formatter: (x) => {return x/1000;}}) // amp
-		.floatle('ShuntPowerVA',	{ formatter: (x) => {return x/1000;}}) // kW 
+// Category    = Aggregated telemetry
+// Object      = Rapid
+// Description = Combined status - Rapid
+// MsgLength   = 50
+// Version     = 2
+// Frequency   = 300 mS
+// Support     = Current
+// Valid from  = SW 1.0.30
+const status = new Parser()
+	.skip(8)
+	.int16le('MinCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.int16le('MaxCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.uint8('MinCellVoltId')
+	.uint8('MaxCellVoltId')
+	.uint8('MinCellTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('MaxCellTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('MinCellTempId')
+	.uint8('MaxCellTempId')
+	.int16le('MinBypassAmp', 	{ formatter: (x) => {return x/1000;}})
+	.int16le('MaxBypassAmp', 	{ formatter: (x) => {return x/1000;}})
+	.uint8('MinBypassAmpId')
+	.uint8('MaxBypassAmpId')
+	.uint8('MinBypassTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('MaxBypassTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('MinBypassTempId',	{ formatter: (x) => {return x-40;}})
+	.uint8('MaxBypassTempId',	{ formatter: (x) => {return x-40;}})
+	.int16le('AvgCellVolt',   	{ formatter: (x) => {return x/1000;}})
+	.uint8('AvgCellTemp',    	{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('NumOfCellsAboveInitialBypass')
+	.uint8('NumOfCellsAboveFinalBypass')
+	.uint8('NumOfCellsInBypass')
+	.uint8('NumOfCellsOverdue')
+	.uint8('NumOfCellsActive')
+	.uint8('NumOfCellsInSystem')
+	.uint8('CmuTxOpStatusId')
+	.uint8('CmuRxOpStatusId')
+	.uint8('CmuRxOpStatusUSN')
+	.int16le('ShuntVoltage',	{ formatter: (x) => {return x/100;}})  // voltage
+	.floatle('ShuntCurrent',	{ formatter: (x) => {return x/1000;}}) // amp
+	.floatle('ShuntPowerVA',	{ formatter: (x) => {return x/1000;}}) // kW
 
-		return status.parse(msg);
-	}
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_3e5a_StatusRapid.js
+++ b/payload/Msg_3e5a_StatusRapid.js
@@ -1,51 +1,48 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Aggregated telemetry
-	// Object      = Rapid
-	// Description = Combined status - Rapid
-	// MsgLength   = 48
-	// Version     = 1
-	// Frequency   = 300 mS
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_3e5a = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.int16le('MinCellVolt',		{ formatter: (x) => {return x/1000;}})
-		.int16le('MaxCellVolt',		{ formatter: (x) => {return x/1000;}})
-		.uint8('MinCellVoltId')
-		.uint8('MaxCellVoltId')
-		.uint8('MinCellTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('MaxCellTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('MinCellTempId')
-		.uint8('MaxCellTempId')
-		.int16le('MinBypassAmp', 	{ formatter: (x) => {return x/1000;}})
-		.int16le('MaxBypassAmp', 	{ formatter: (x) => {return x/1000;}})
-		.uint8('MinBypassAmpId')
-		.uint8('MaxBypassAmpId')
-		.uint8('MinBypassTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('MaxBypassTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('MinBypassTempId',	{ formatter: (x) => {return x-40;}})
-		.uint8('MaxBypassTempId',	{ formatter: (x) => {return x-40;}})
-		.int16le('AvgCellVolt',   	{ formatter: (x) => {return x/1000;}})
-		.uint8('AvgCellTemp',    	{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('NumOfCellsAboveInitialBypass')
-		.uint8('NumOfCellsAboveFinalBypass')
-		.uint8('NumOfCellsInBypass')
-		.uint8('NumOfCellsOverdue')
-		.uint8('NumOfCellsActive')
-		.uint8('NumOfCellsInSystem')
-		.uint8('CmuTxOpStatusId')
-		.uint8('CmuRxOpStatusId')
-		.uint8('CmuRxOpStatusUSN')
-		.int16le('ShuntVoltage',	{ formatter: (x) => {return x/100;}})
-		.floatle('ShuntCurrent',	{ formatter: (x) => {return x/1000;}})
-		.uint8('ShuntRxAmpTicks')
-		.uint8('ShuntTxAmpTicks')
+// Category    = Aggregated telemetry
+// Object      = Rapid
+// Description = Combined status - Rapid
+// MsgLength   = 48
+// Version     = 1
+// Frequency   = 300 mS
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.int16le('MinCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.int16le('MaxCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.uint8('MinCellVoltId')
+	.uint8('MaxCellVoltId')
+	.uint8('MinCellTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('MaxCellTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('MinCellTempId')
+	.uint8('MaxCellTempId')
+	.int16le('MinBypassAmp', 	{ formatter: (x) => {return x/1000;}})
+	.int16le('MaxBypassAmp', 	{ formatter: (x) => {return x/1000;}})
+	.uint8('MinBypassAmpId')
+	.uint8('MaxBypassAmpId')
+	.uint8('MinBypassTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('MaxBypassTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('MinBypassTempId',	{ formatter: (x) => {return x-40;}})
+	.uint8('MaxBypassTempId',	{ formatter: (x) => {return x-40;}})
+	.int16le('AvgCellVolt',   	{ formatter: (x) => {return x/1000;}})
+	.uint8('AvgCellTemp',    	{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('NumOfCellsAboveInitialBypass')
+	.uint8('NumOfCellsAboveFinalBypass')
+	.uint8('NumOfCellsInBypass')
+	.uint8('NumOfCellsOverdue')
+	.uint8('NumOfCellsActive')
+	.uint8('NumOfCellsInSystem')
+	.uint8('CmuTxOpStatusId')
+	.uint8('CmuRxOpStatusId')
+	.uint8('CmuRxOpStatusUSN')
+	.int16le('ShuntVoltage',	{ formatter: (x) => {return x/100;}})
+	.floatle('ShuntCurrent',	{ formatter: (x) => {return x/1000;}})
+	.uint8('ShuntRxAmpTicks')
+	.uint8('ShuntTxAmpTicks')
 
-		return status.parse(msg);
-	}
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_3f33_StatusFast.js
+++ b/payload/Msg_3f33_StatusFast.js
@@ -1,111 +1,108 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Aggregated telemetry
-	// Object      = Fast
-	// MsgLength   = 80
-	// Description = Combined status Fast
-	// Version     = 3
-	// Frequency   = 2 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_3f33 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('CmuPollerMode') 	    /* Choices
-				Idle = 0,
-				Normal = 1,
-				Collection Start = 2,
-				Collection Running = 3,
-				Sync Start = 4,
-				Sync Running = 5,
-				NetworkTest Start = 6,
-				NetworkTest Running = 9,
-				BypassTest Start = 7,
-				BypassTest Running = 8,
-				RebootAll Start = 10,
-				Rebooting AllDevices = 11,
-				Simulator Start = 12,
-				Simulator Running = 13, */
-		.uint8('CmuTxAckCount')            // Cellmon TX Acknowledgement Count
-		.uint8('CmuTxOpStatusNodeId')      // Cellmon TX Operating Status Node ID
-		.uint8('CmuTxOpStatusUSN')         // Cellmon TX Operating Status Universal Serial Number
-		.uint8('CmuTxOpParamNodeId')       // Cellmon TX Parameter Node ID
-		.int16le('GroupMinCellVolt',		{ formatter: (x) => {return x/1000;}})
-		.int16le('GroupMaxCellVolt',		{ formatter: (x) => {return x/1000;}})		
-		.uint8('GroupMinCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('GroupMaxCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('CmuRxOpStatusNodeId')
-		.uint8('CmuRxOpStatusGroupAck')
-		.uint8('CmuRxOpStatusUSN')
-		.uint8('CmuRxOpParamNodeId')
-		.uint8('SystemOpStatus') /* Choices
-				Simulator = 0,   	  // LED = rainbow pulse
-				Idle = 1,        	  // LED = green slow pulse
-				Discharging = 2, 	  // LED = green solid 
-				SoC Empty = 3,   	  // LED = green double blink
-				Charging = 4,    	  // LED = blue slow pulse
-				Full = 5,        	  // LED = blue double blink
-				Timeout = 6,     	  // LED = red solid
-				Critical Pending = 7, // LED = red fast pulse
-				Critical Offline = 8, // LED = red slow pulse
-				Mqtt Offline = 9,     // LED = white blink
-				Auth Setup = 10,      // LED = white solid
-				Shunt Timeout = 11,   // LED = red solid  	*/
-		.uint8('SystemAuthMode') /* Choices
-				Default = 0,
-				Technician = 1,
-				Factory = 2, */
-		.int16le('SupplyVolt',				{ formatter: (x) => {return x/100;}})
-		.uint8('AmbientTemp',				{ formatter: (x) => {return x-40;}})   // temperature ºC
-		.uint32le('SystemTime') // Epoch
-		.uint8('ShuntSOC', 					{ formatter: (x) => {return x/2-5;}})  // percent
-		.uint8('ShuntTemp',					{ formatter: (x) => {return x-40;}})   // temperature ºC
-		.floatle('NomCapacityToFull',		{ formatter: (x) => {return x/1000;}}) // Ah
-		.floatle('NomCapacityToEmpty',		{ formatter: (x) => {return x/1000;}}) // Ah
-		.uint8('ShuntPollerMode') /* Choices
-				Idle Start = 0,
-				Idle = 1,
-				Sync Start = 2,
-				Sync Running = 3,
-				Normal = 4,
-				ShuntMon2 SetupStart = 5,
-				ShuntMon2 SetupRunning = 6,
-				ShuntMon2 Normal = 7, */
-		.uint8('ShuntStatus') /* Choices
-				Timeout = 0,
-				Discharging = 1,
-				Idle = 2,
-				Charging = 4 */
-		.uint8('hasShuntLoSocRecal')		// boolean 0 = Off , 1 = On
-		.uint8('hasShuntHiSocRecal') 		// boolean 0 = Off , 1 = On
-		//  shunt.hasShuntOkSocRange = !(shunt.hasShuntLoSocRecal || shunt.hasShuntHiSocRecal);
-		.uint8('ExpansionOutputFet5') 		// boolean 0 = Off , 1 = On
-		.uint8('ExpansionOutputFet6') 		// boolean 0 = Off , 1 = On
-		.uint8('ExpansionOutputFet7') 		// boolean 0 = Off , 1 = On
-		.uint8('ExpansionOutputFet8') 		// boolean 0 = Off , 1 = On
-		.uint8('ExpansionOutputRelay1') 	// boolean 0 = Off , 1 = On
-		.uint8('ExpansionOutputRelay2') 	// boolean 0 = Off , 1 = On
-		.uint8('ExpansionOutputRelay3') 	// boolean 0 = Off , 1 = On
-		.uint8('ExpansionOutputRelay4') 	// boolean 0 = Off , 1 = On
-		.int16le('ExpansionOutputPwm1') 
-		.int16le('ExpansionOutputPwm2') 
-		.uint8('ExpansionInput1') 			// boolean 0 = Off , 1 = On
-		.uint8('ExpansionInput2') 			// boolean 0 = Off , 1 = On
-		.uint8('ExpansionInput3') 			// boolean 0 = Off , 1 = On
-		.uint8('ExpansionInput4') 			// boolean 0 = Off , 1 = On
-		.uint8('ExpansionInput5') 
-		.int16le('ExpansionInputAIN1') 
-		.int16le('ExpansionInputAIN2') 
-		.floatle('MinBypassSession', 		{ formatter: (x) => {return x/1000;}}) // Ah
-		.floatle('MaxBypassSession', 		{ formatter: (x) => {return x/1000;}}) // Ah
-		.uint8('MinBypassSessionID')
-		.uint8('MaxBypassSessionID')
-		.uint8('RebalanceBypassExtra')  	// boolean 0 = Off , 1 = On
-		.int16le('RepeatCellVoltCounter') 
-		
-		return status.parse(msg);
-	}
+// Category    = Aggregated telemetry
+// Object      = Fast
+// MsgLength   = 80
+// Description = Combined status Fast
+// Version     = 3
+// Frequency   = 2 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('CmuPollerMode') 	    /* Choices
+			Idle = 0,
+			Normal = 1,
+			Collection Start = 2,
+			Collection Running = 3,
+			Sync Start = 4,
+			Sync Running = 5,
+			NetworkTest Start = 6,
+			NetworkTest Running = 9,
+			BypassTest Start = 7,
+			BypassTest Running = 8,
+			RebootAll Start = 10,
+			Rebooting AllDevices = 11,
+			Simulator Start = 12,
+			Simulator Running = 13, */
+	.uint8('CmuTxAckCount')            // Cellmon TX Acknowledgement Count
+	.uint8('CmuTxOpStatusNodeId')      // Cellmon TX Operating Status Node ID
+	.uint8('CmuTxOpStatusUSN')         // Cellmon TX Operating Status Universal Serial Number
+	.uint8('CmuTxOpParamNodeId')       // Cellmon TX Parameter Node ID
+	.int16le('GroupMinCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.int16le('GroupMaxCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.uint8('GroupMinCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('GroupMaxCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('CmuRxOpStatusNodeId')
+	.uint8('CmuRxOpStatusGroupAck')
+	.uint8('CmuRxOpStatusUSN')
+	.uint8('CmuRxOpParamNodeId')
+	.uint8('SystemOpStatus') /* Choices
+			Simulator = 0,   	  // LED = rainbow pulse
+			Idle = 1,        	  // LED = green slow pulse
+			Discharging = 2, 	  // LED = green solid
+			SoC Empty = 3,   	  // LED = green double blink
+			Charging = 4,    	  // LED = blue slow pulse
+			Full = 5,        	  // LED = blue double blink
+			Timeout = 6,     	  // LED = red solid
+			Critical Pending = 7, // LED = red fast pulse
+			Critical Offline = 8, // LED = red slow pulse
+			Mqtt Offline = 9,     // LED = white blink
+			Auth Setup = 10,      // LED = white solid
+			Shunt Timeout = 11,   // LED = red solid  	*/
+	.uint8('SystemAuthMode') /* Choices
+			Default = 0,
+			Technician = 1,
+			Factory = 2, */
+	.int16le('SupplyVolt',				{ formatter: (x) => {return x/100;}})
+	.uint8('AmbientTemp',				{ formatter: (x) => {return x-40;}})   // temperature ºC
+	.uint32le('SystemTime') // Epoch
+	.uint8('ShuntSOC', 					{ formatter: (x) => {return x/2-5;}})  // percent
+	.uint8('ShuntTemp',					{ formatter: (x) => {return x-40;}})   // temperature ºC
+	.floatle('NomCapacityToFull',		{ formatter: (x) => {return x/1000;}}) // Ah
+	.floatle('NomCapacityToEmpty',		{ formatter: (x) => {return x/1000;}}) // Ah
+	.uint8('ShuntPollerMode') /* Choices
+			Idle Start = 0,
+			Idle = 1,
+			Sync Start = 2,
+			Sync Running = 3,
+			Normal = 4,
+			ShuntMon2 SetupStart = 5,
+			ShuntMon2 SetupRunning = 6,
+			ShuntMon2 Normal = 7, */
+	.uint8('ShuntStatus') /* Choices
+			Timeout = 0,
+			Discharging = 1,
+			Idle = 2,
+			Charging = 4 */
+	.uint8('hasShuntLoSocRecal')		// boolean 0 = Off , 1 = On
+	.uint8('hasShuntHiSocRecal') 		// boolean 0 = Off , 1 = On
+	//  shunt.hasShuntOkSocRange = !(shunt.hasShuntLoSocRecal || shunt.hasShuntHiSocRecal);
+	.uint8('ExpansionOutputFet5') 		// boolean 0 = Off , 1 = On
+	.uint8('ExpansionOutputFet6') 		// boolean 0 = Off , 1 = On
+	.uint8('ExpansionOutputFet7') 		// boolean 0 = Off , 1 = On
+	.uint8('ExpansionOutputFet8') 		// boolean 0 = Off , 1 = On
+	.uint8('ExpansionOutputRelay1') 	// boolean 0 = Off , 1 = On
+	.uint8('ExpansionOutputRelay2') 	// boolean 0 = Off , 1 = On
+	.uint8('ExpansionOutputRelay3') 	// boolean 0 = Off , 1 = On
+	.uint8('ExpansionOutputRelay4') 	// boolean 0 = Off , 1 = On
+	.int16le('ExpansionOutputPwm1')
+	.int16le('ExpansionOutputPwm2')
+	.uint8('ExpansionInput1') 			// boolean 0 = Off , 1 = On
+	.uint8('ExpansionInput2') 			// boolean 0 = Off , 1 = On
+	.uint8('ExpansionInput3') 			// boolean 0 = Off , 1 = On
+	.uint8('ExpansionInput4') 			// boolean 0 = Off , 1 = On
+	.uint8('ExpansionInput5')
+	.int16le('ExpansionInputAIN1')
+	.int16le('ExpansionInputAIN2')
+	.floatle('MinBypassSession', 		{ formatter: (x) => {return x/1000;}}) // Ah
+	.floatle('MaxBypassSession', 		{ formatter: (x) => {return x/1000;}}) // Ah
+	.uint8('MinBypassSessionID')
+	.uint8('MaxBypassSessionID')
+	.uint8('RebalanceBypassExtra')  	// boolean 0 = Off , 1 = On
+	.int16le('RepeatCellVoltCounter')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4032_StatusSlow.js
+++ b/payload/Msg_4032_StatusSlow.js
@@ -1,50 +1,47 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Aggregated telemetry
-	// Object      = Slow
-	// Description = Combined status - Slow
-	// MsgLength   = 66
-	// Version     = 2
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_4032 = function(msg) 
-	{
-			
-		var status = new Parser()
-		.skip(8)
-		.uint32le('SystemTime') 			// Epoch
-		.uint8('IsProcessControl') 			// boolean 0 = Off , 1 = On
-		.uint8('IsInitialStartup') 			// boolean 0 = Off , 1 = On
-		.uint8('IgnoreWhenCellsOverdue') 	// boolean 0 = Off , 1 = On
-		.uint8('IgnoreWhenShuntsOverdue') 	// boolean 0 = Off , 1 = On
-		.uint8('MonitorDailySessionStats') 	// boolean 0 = Off , 1 = On		
-		.uint8('HwSystemSetupVers') 
-		.uint8('HwCellmonSetupVers') 
-		.uint8('HwShuntSetupVers') 
-		.uint8('HwExpansionSetupVers') 
-		.uint8('HwIntegrationSetupVers') 
-		.uint8('ControlCriticalSetupVers') 
-		.uint8('ControlChargeSetupVers')  
-		.uint8('ControlDischargeSetupVers')  		
-		.uint8('ControlThermalSetupVers')  
-		.uint8('ControlRemoteSetupVers')  
-		.uint8('ControlSchedulerSetupVers') 			
-		.int16le('EstDurationToFullmins') 
-		.int16le('EstDurationToEmptymins') 
-		.floatle('ShuntAcculmAvgCharge',	{ formatter: (x) => {return x/1000;}}) // Ah
-		.floatle('ShuntAcculmAvgDischg',	{ formatter: (x) => {return x/1000;}}) // Ah
-		.floatle('ShuntAcculmAvgNett',		{ formatter: (x) => {return x/1000;}}) // Ah
-		.uint8(  'hasShuntSocCountLo') 		// boolean 0 = Off , 1 = On
-		.uint8(  'hasShuntSocCountHi') 		// boolean 0 = Off , 1 = On		
-		.uint32le('QuickSessRecentTime') 	// EPOCH
-		.int16le('QuickSessNumOfRecords')
-		.int16le('QuickSessMaxNumOfRecords')
-		.skip(8) // acculmNett ADC counter 
-		.floatle('NomCapacityToEmpty',		{ formatter: (x) => {return x/1000;}}) // Ah
-		
-		return status.parse(msg);
-	}
+// Category    = Aggregated
+// Object      =
+// Description = Combined status -
+// MsgLength   =
+// Version     =
+// Frequency   = 20
+// Support     =
+// Valid to    = SW 1.0.
+
+const status = new Parser()
+	.skip(8)
+	.uint32le('SystemTime') 			//
+	.uint8('IsProcessControl') 			// boolean 0 = Off , 1 =
+	.uint8('IsInitialStartup') 			// boolean 0 = Off , 1 =
+	.uint8('IgnoreWhenCellsOverdue') 	// boolean 0 = Off , 1 =
+	.uint8('IgnoreWhenShuntsOverdue') 	// boolean 0 = Off , 1 =
+	.uint8('MonitorDailySessionStats') 	// boolean 0 = Off , 1 =
+	.uint8('HwSystemSetupVers')
+	.uint8('HwCellmonSetupVers')
+	.uint8('HwShuntSetupVers')
+	.uint8('HwExpansionSetupVers')
+	.uint8('HwIntegrationSetupVers')
+	.uint8('ControlCriticalSetupVers')
+	.uint8('ControlChargeSetupVers')
+	.uint8('ControlDischargeSetupVers')
+	.uint8('ControlThermalSetupVers')
+	.uint8('ControlRemoteSetupVers')
+	.uint8('ControlSchedulerSetupVers')
+	.int16le('EstDurationToFullmins')
+	.int16le('EstDurationToEmptymins')
+	.floatle('ShuntAcculmAvgCharge',	{ formatter: (x) => {return x/1000;}}) //
+	.floatle('ShuntAcculmAvgDischg',	{ formatter: (x) => {return x/1000;}}) //
+	.floatle('ShuntAcculmAvgNett',		{ formatter: (x) => {return x/1000;}}) //
+	.uint8(  'hasShuntSocCountLo') 		// boolean 0 = Off , 1 =
+	.uint8(  'hasShuntSocCountHi') 		// boolean 0 = Off , 1 = On
+	.uint32le('QuickSessRecentTime') 	//
+	.int16le('QuickSessNumOfRecords')
+	.int16le('QuickSessMaxNumOfRecords')
+	.skip(8) // acculmNett ADC
+	.floatle('NomCapacityToEmpty',		{ formatter: (x) => {return x/1000;}}) //
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_415a_CellNodeStatus.js
+++ b/payload/Msg_415a_CellNodeStatus.js
@@ -1,53 +1,48 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Telemetry
-	// Object      = CellNodeItem
-	// Description = Cell node - array up to 16 nodes
-	// MsgLength   = variable
-	// Version     = 1
-	// Frequency   = 300 mS
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_415a = function(msg) 
-	{		
-		var subParser = new Parser()
-		.uint8('ID')
-                .uint8('USN')
-                .int16le('MinCellVolt',                 { formatter: (x) => {return x/1000;}})
-                .int16le('MaxCellVolt',                 { formatter: (x) => {return x/1000;}})
-                .uint8('MinCellTemp',                   { formatter: (x) => {return x-40;}}) // temperature ºC
-                .uint8('BypassTemp',                    { formatter: (x) => {return x-40;}}) // temperature ºC
-                .int16le('BypassAmp',                   { formatter: (x) => {return x/1000;}})
-                .uint8('Status'); /* Choices NodeStatuses
-						None = 0,
-						HighVolt = 1,
-						HighTemp = 2,
-						Ok = 3,
-						Timeout = 4,
-						LowVolt = 5,
-						Disabled = 6,
-						InBypass = 7,
-						InitialBypass = 8,
-						FinalBypass = 9,
-						MissingSetup = 10,
-						NoConfig = 11,
-						CellOutLimits = 12, */
+// Category    = Telemetry
+// Object      = CellNodeItem
+// Description = Cell node - array up to 16 nodes
+// MsgLength   = variable
+// Version     = 1
+// Frequency   = 300 mS
+// Support     = Current
+// Valid to    = SW 1.0.29
+const subParser = new Parser()
+	.uint8('ID')
+	.uint8('USN')
+	.int16le('MinCellVolt',                 { formatter: (x) => {return x/1000;}})
+	.int16le('MaxCellVolt',                 { formatter: (x) => {return x/1000;}})
+	.uint8('MinCellTemp',                   { formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('BypassTemp',                    { formatter: (x) => {return x-40;}}) // temperature ºC
+	.int16le('BypassAmp',                   { formatter: (x) => {return x/1000;}})
+	.uint8('Status'); /* Choices NodeStatuses
+					None = 0,
+					HighVolt = 1,
+					HighTemp = 2,
+					Ok = 3,
+					Timeout = 4,
+					LowVolt = 5,
+					Disabled = 6,
+					InBypass = 7,
+					InitialBypass = 8,
+					FinalBypass = 9,
+					MissingSetup = 10,
+					NoConfig = 11,
+					CellOutLimits = 12, */
 
-		var status = new Parser()
-		.skip(8)
-		.uint8('CmuRxOpStatusNodeID')
-		.uint8('Records')
-		.uint8('FirstNodeID')
-		.uint8('LastNodeID')
-		.array('nodes', {
-			type : subParser,
-			length : 'Records'
-		})
+const status = new Parser()
+	.skip(8)
+	.uint8('CmuRxOpStatusNodeID')
+	.uint8('Records')
+	.uint8('FirstNodeID')
+	.uint8('LastNodeID')
+	.array('nodes', {
+		type : subParser,
+		length : 'Records'
+	});
 
-		return status.parse(msg);
-	}
-
-
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4232_CellNodeFull.js
+++ b/payload/Msg_4232_CellNodeFull.js
@@ -1,59 +1,56 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Telemetry
-	// Object      = CellNodeItem
-	// Description = Cell node - full details
-	// MsgLength   = 52
-	// Version     = 2
-	// Frequency   = 300 mS
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_4232 = function(msg) 
-	{		
-		var status = new Parser()
-		.skip(8)
-		.uint8('ID')
-		.uint8('USN')
-		.int16le('MinCellVolt',			{ formatter: (x) => {return x/1000;}})
-		.int16le('MaxCellVolt',			{ formatter: (x) => {return x/1000;}})
-		.uint8('MinCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('BypassTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.int16le('BypassAmp', 			{ formatter: (x) => {return x/1000;}})
-		.uint8('DataErrorCounter')
-		.uint8('ResetCounter')
-		.uint8('Status') /* Choices NodeStatuses
-				None = 0,
-				HighVolt = 1,
-				HighTemp = 2,
-				Ok = 3,
-				Timeout = 4,
-				LowVolt = 5,
-				Disabled = 6,
-				InBypass = 7,
-				InitialBypass = 8,
-				FinalBypass = 9,
-				MissingSetup = 10,
-				NoConfig = 11,
-				CellOutLimits = 12, */	
-		.uint8('IsOverdue')				// boolean 0 = Off , 1 = On
+// Category    = Telemetry
+// Object      = CellNodeItem
+// Description = Cell node - full details
+// MsgLength   = 52
+// Version     = 2
+// Frequency   = 300 mS
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('ID')
+	.uint8('USN')
+	.int16le('MinCellVolt',			{ formatter: (x) => {return x/1000;}})
+	.int16le('MaxCellVolt',			{ formatter: (x) => {return x/1000;}})
+	.uint8('MinCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('BypassTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.int16le('BypassAmp', 			{ formatter: (x) => {return x/1000;}})
+	.uint8('DataErrorCounter')
+	.uint8('ResetCounter')
+	.uint8('Status') /* Choices NodeStatuses
+			None = 0,
+			HighVolt = 1,
+			HighTemp = 2,
+			Ok = 3,
+			Timeout = 4,
+			LowVolt = 5,
+			Disabled = 6,
+			InBypass = 7,
+			InitialBypass = 8,
+			FinalBypass = 9,
+			MissingSetup = 10,
+			NoConfig = 11,
+			CellOutLimits = 12, */
+	.uint8('IsOverdue')				// boolean 0 = Off , 1 = On
 
-		.int16le('LoCellVoltAlert',		{ formatter: (x) => {return x/1000;}})
-		.int16le('HiCellVoltAlert',		{ formatter: (x) => {return x/1000;}})
-		.int16le('BypassVoltLevel',		{ formatter: (x) => {return x/1000;}})
-		.int16le('BypassAmpLimit',		{ formatter: (x) => {return x/1000;}})
-		.uint8('BypassTempLimit',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('HiCellTempAlert',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('RawVoltCalOffset')
-		.int16le('FwVers')
-		.int16le('HwVers')
-		.int16le('BootVers')
-		.uint32le('SerialNo')	
-		.uint32le('BypassInitialDate') 	// Epoch
-		.floatle('BypassSessionAh',		{ formatter: (x) => {return x/1000;}}) // Ah
-		.uint8('RepeatCellV')
-		
-		return status.parse(msg);
-	}
+	.int16le('LoCellVoltAlert',		{ formatter: (x) => {return x/1000;}})
+	.int16le('HiCellVoltAlert',		{ formatter: (x) => {return x/1000;}})
+	.int16le('BypassVoltLevel',		{ formatter: (x) => {return x/1000;}})
+	.int16le('BypassAmpLimit',		{ formatter: (x) => {return x/1000;}})
+	.uint8('BypassTempLimit',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('HiCellTempAlert',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('RawVoltCalOffset')
+	.int16le('FwVers')
+	.int16le('HwVers')
+	.int16le('BootVers')
+	.uint32le('SerialNo')
+	.uint32le('BypassInitialDate') 	// Epoch
+	.floatle('BypassSessionAh',		{ formatter: (x) => {return x/1000;}}) // Ah
+	.uint8('RepeatCellV')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_475a_StatusControlLogic.js
+++ b/payload/Msg_475a_StatusControlLogic.js
@@ -1,98 +1,94 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Aggregated telemetry
-	// Object      = CtrlLogic
-	// Description = Combined status - Control logic
-	// MsgLength   = 79
-	// Version     = 1
-	// Frequency   = 2 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_475a = function(msg) 
-	{
-			
-		var status = new Parser()
-		.skip(8)
-		uint8('isCriticalBattOkState')  		// Boolean 0 = Off , 1 = On
-		uint8('isCriticalBattOkCalc')  			// Boolean 0 = Off , 1 = On
-		uint8('isCriticalTransition')  			// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalCellOverdue')  		// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalCellVoltLo')  		// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalCellVoltHi')  		// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalCellTempLo')  		// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalCellTempHi')  		// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalSupplyVoltLo')  		// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalSupplyVoltHi')  		// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalAmbientLo')  			// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalAmbientHi')  			// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalShuntVoltLo')  		// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalShuntVoltHi')  		// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalShuntVoltLoIdle')  	// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalShuntPeakCharge')  	// Boolean 0 = Off , 1 = On
-		uint8('hasCriticalShuntPeakDischg')  	// Boolean 0 = Off , 1 = On
-		uint8('isChargeOnState')  				// Boolean 0 = Off , 1 = On
-		uint8('isChargeLimPower')  				// Boolean 0 = Off , 1 = On
-		uint8('isChargeTransition')  			// Boolean 0 = Off , 1 = On
-		uint8('isChargePowerRateState') /* Choices ChargeRateStates
-				Off 			= 0,
-				Limited Power 	= 2,
-				Normal Power  	= 4, */
-		uint8('isChargePowerRateCalc')  		/* Choices ChargeRateStates */
-		uint8('hasChargeCellVoltHi ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasChargeCellVoltPause ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasChargeCellVoltLimPower ')  	// Boolean 0 = Off , 1 = On
-		uint8('hasChargeCellTempLo ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasChargeCellTempHi ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasChargeAmbientTempLo ') 		// Boolean 0 = Off , 1 = On
-		uint8('hasChargeAmbientTempHi ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasChargeSupplyVoltHi ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasChargeSupplyVoltPause ')  	// Boolean 0 = Off , 1 = On
-		uint8('hasChargeShuntVoltHi ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasChargeShuntVoltPause ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasChargeShuntVoltLimPower ')  	// Boolean 0 = Off , 1 = On
-		uint8('hasChargeShuntSocHi ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasChargeShuntSocPause ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasChargeAboveInitalBypass ')	// Boolean 0 = Off , 1 = On
-		uint8('hasChargeAboveFinalBypass ')		// Boolean 0 = Off , 1 = On
-		uint8('hasChargeInBypass ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasChargeBypassComplete ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasChargeBypassTempRelief ')  	// Boolean 0 = Off , 1 = On
-		uint8('hasChargeBypassSessionLo ')  	// Boolean 0 = Off , 1 = On
-		uint8('isDischgOnState ')  				// Boolean 0 = Off , 1 = On
-		uint8('isDischgLimPower ')  			// Boolean 0 = Off , 1 = On
-		uint8('isDischgTransition ')  			// Boolean 0 = Off , 1 = On
-		uint8('isDischgPowerRateState ') /* Choices DischgRateStates
-				Off 			= 0,
-				Limited Power 	= 2,
-				Normal Power  	= 4, */		
-		uint8('isDischgPowerRateCalc ')  		/* Choices DischgRateStates */
-		uint8('hasDischgCellVoltLo ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasDischgCellVoltPause ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasDischgCellVoltLimPower ')  	// Boolean 0 = Off , 1 = On
-		uint8('hasDischgCellTempLo ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasDischgCellTempHi ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasDischgAmbientLo ')	  		// Boolean 0 = Off , 1 = On
-		uint8('hasDischgAmbientHi ') 			// Boolean 0 = Off , 1 = On
-		uint8('hasDischgSupplyVoltLo ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasDischgSupplyVoltPause ')  	// Boolean 0 = Off , 1 = On
-		uint8('hasDischgShuntVoltLo ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasDischgShuntVoltPause ')  		// Boolean 0 = Off , 1 = On
-		uint8('hasDischgShuntVoltLimPower ')  	// Boolean 0 = Off , 1 = On
-		uint8('hasDischgShuntSocLo ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasDischgShuntSocPause ')  		// Boolean 0 = Off , 1 = On
-		uint8('isHeatOnState ')  				// Boolean 0 = Off , 1 = On
-		uint8('isHeatOnCalc ')  				// Boolean 0 = Off , 1 = On
-		uint8('isHeatTransition ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasHeatAmbientLo ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasHeatCellTempLo ')  			// Boolean 0 = Off , 1 = On
-		uint8('isCoolOnState')  				// Boolean 0 = Off , 1 = On
-		uint8('isCoolOnCalc')  					// Boolean 0 = Off , 1 = On
-		uint8('isCoolTransition')  				// Boolean 0 = Off , 1 = On
-		uint8('hasCoolAmbientHi ')  			// Boolean 0 = Off , 1 = On
-		uint8('hasCoolCellTempHi ')  			// Boolean 0 = Off , 1 = On
+// Category    = Aggregated telemetry
+// Object      = CtrlLogic
+// Description = Combined status - Control logic
+// MsgLength   = 79
+// Version     = 1
+// Frequency   = 2 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('isCriticalBattOkState')  		// Boolean 0 = Off , 1 = On
+	.uint8('isCriticalBattOkCalc')  			// Boolean 0 = Off , 1 = On
+	.uint8('isCriticalTransition')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalCellOverdue')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalCellVoltLo')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalCellVoltHi')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalCellTempLo')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalCellTempHi')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalSupplyVoltLo')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalSupplyVoltHi')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalAmbientLo')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalAmbientHi')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalShuntVoltLo')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalShuntVoltHi')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalShuntVoltLoIdle')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalShuntPeakCharge')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasCriticalShuntPeakDischg')  	// Boolean 0 = Off , 1 = On
+	.uint8('isChargeOnState')  				// Boolean 0 = Off , 1 = On
+	.uint8('isChargeLimPower')  				// Boolean 0 = Off , 1 = On
+	.uint8('isChargeTransition')  			// Boolean 0 = Off , 1 = On
+	.uint8('isChargePowerRateState') /* Choices ChargeRateStates
+			Off 			= 0,
+			Limited Power 	= 2,
+			Normal Power  	= 4, */
+	.uint8('isChargePowerRateCalc')  		/* Choices ChargeRateStates */
+	.uint8('hasChargeCellVoltHi ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeCellVoltPause ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeCellVoltLimPower ')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeCellTempLo ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeCellTempHi ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeAmbientTempLo ') 		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeAmbientTempHi ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeSupplyVoltHi ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeSupplyVoltPause ')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntVoltHi ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntVoltPause ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntVoltLimPower ')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntSocHi ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntSocPause ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeAboveInitalBypass ')	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeAboveFinalBypass ')		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeInBypass ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeBypassComplete ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeBypassTempRelief ')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeBypassSessionLo ')  	// Boolean 0 = Off , 1 = On
+	.uint8('isDischgOnState ')  				// Boolean 0 = Off , 1 = On
+	.uint8('isDischgLimPower ')  			// Boolean 0 = Off , 1 = On
+	.uint8('isDischgTransition ')  			// Boolean 0 = Off , 1 = On
+	.uint8('isDischgPowerRateState ') /* Choices DischgRateStates
+			Off 			= 0,
+			Limited Power 	= 2,
+			Normal Power  	= 4, */
+	.uint8('isDischgPowerRateCalc ')  		/* Choices DischgRateStates */
+	.uint8('hasDischgCellVoltLo ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgCellVoltPause ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgCellVoltLimPower ')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgCellTempLo ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgCellTempHi ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgAmbientLo ')	  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgAmbientHi ') 			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgSupplyVoltLo ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgSupplyVoltPause ')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntVoltLo ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntVoltPause ')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntVoltLimPower ')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntSocLo ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntSocPause ')  		// Boolean 0 = Off , 1 = On
+	.uint8('isHeatOnState ')  				// Boolean 0 = Off , 1 = On
+	.uint8('isHeatOnCalc ')  				// Boolean 0 = Off , 1 = On
+	.uint8('isHeatTransition ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasHeatAmbientLo ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasHeatCellTempLo ')  			// Boolean 0 = Off , 1 = On
+	.uint8('isCoolOnState')  				// Boolean 0 = Off , 1 = On
+	.uint8('isCoolOnCalc')  					// Boolean 0 = Off , 1 = On
+	.uint8('isCoolTransition')  				// Boolean 0 = Off , 1 = On
+	.uint8('hasCoolAmbientHi ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasCoolCellTempHi ')  			// Boolean 0 = Off , 1 = On
 
-		return status.parse(msg);
-	}
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4932_ControlRemoteStatus.js
+++ b/payload/Msg_4932_ControlRemoteStatus.js
@@ -1,44 +1,41 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Aggregated telemetry
-	// Object      = Remote
-	// MsgLength   = 62
-	// Description = Control remote status
-	// Version     = 2
-	// Frequency   = 2 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_4932 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('CanbusRxStatusTicks')  
-		.uint8('CanbusRxUnknownTicks')  
-		.uint8('CanbusTxCmdTicks')  
-		.uint8(  'RemoteChargeActualCelcius', 		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.int16le('RemoteChargeTargetVolt')
-		.int16le('RemoteChargeTargetAmp')
-		.int16le('RemoteChargeTargetVA')
-		.int16le('RemoteChargeActualVolt')
-		.int16le('RemoteChargeActualAmp')
-		.int16le('RemoteChargeActualVA')
-		.uint32le('RemoteChargeActualFlag1')
-		.uint32le('RemoteChargeActualFlag2')
-		.uint32le('RemoteChargeActualRxTime') // Epoch
-		.skip(1)
-		.uint8(  'RemoteDishargeActualCelcius', 	{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.int16le('RemoteDischargeTargetVolt')
-		.int16le('RemoteDischargeTargetAmp')
-		.int16le('RemoteDischargeTargetVA')
-		.int16le('RemoteDischargeActualVolt')
-		.int16le('RemoteDischargeActualAmp')
-		.int16le('RemoteDischargeActualVA')
-		.uint32le('RemoteDischargeActualFlag1')
-		.uint32le('RemoteDischargeActualFlag2')
-		.uint32le('RemoteDischargeActualRxTime') // Epoch
-		
-		return status.parse(msg);
-	}
+// Category    = Aggregated telemetry
+// Object      = Remote
+// MsgLength   = 62
+// Description = Control remote status
+// Version     = 2
+// Frequency   = 2 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('CanbusRxStatusTicks')
+	.uint8('CanbusRxUnknownTicks')
+	.uint8('CanbusTxCmdTicks')
+	.uint8(  'RemoteChargeActualCelcius', 		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.int16le('RemoteChargeTargetVolt')
+	.int16le('RemoteChargeTargetAmp')
+	.int16le('RemoteChargeTargetVA')
+	.int16le('RemoteChargeActualVolt')
+	.int16le('RemoteChargeActualAmp')
+	.int16le('RemoteChargeActualVA')
+	.uint32le('RemoteChargeActualFlag1')
+	.uint32le('RemoteChargeActualFlag2')
+	.uint32le('RemoteChargeActualRxTime') // Epoch
+	.skip(1)
+	.uint8(  'RemoteDishargeActualCelcius', 	{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.int16le('RemoteDischargeTargetVolt')
+	.int16le('RemoteDischargeTargetAmp')
+	.int16le('RemoteDischargeTargetVA')
+	.int16le('RemoteDischargeActualVolt')
+	.int16le('RemoteDischargeActualAmp')
+	.int16le('RemoteDischargeActualVA')
+	.uint32le('RemoteDischargeActualFlag1')
+	.uint32le('RemoteDischargeActualFlag2')
+	.uint32le('RemoteDischargeActualRxTime') // Epoch
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4a34_HwSystemSetup.js
+++ b/payload/Msg_4a34_HwSystemSetup.js
@@ -1,31 +1,28 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Hardware Configuration
-	// Object      = System
-	// MsgLength   = 74
-	// Description = System setup configuration
-	// Version     = 4
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_4a34 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.int16le('HwSystemSetupVers')
-		.string('SystemCode', 	{ encoding: 'ascii', length: 8 })
-		.string('SysName', 		{ encoding: 'ascii', length: 20 })
-		.string('AssetCode', 	{ encoding: 'ascii', length: 20 })
-		.uint8('AllowTechAuth') 		// boolean 0 = Off , 1 = On
-		.uint8('AllowQuickSession') 	// boolean 0 = Off , 1 = On
-		.uint32le('QuickSessionInterval', { formatter: (x) => {return x/1000;}})  // seconds
-		.int16le('SystemPresetId')
-		.int16le('SystemFirmwareVersion')
-		.int16le('SystemHardwareVersion')
-		.uint32le('SystemSerialNo')
+// Category    = Hardware Configuration
+// Object      = System
+// MsgLength   = 74
+// Description = System setup configuration
+// Version     = 4
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.int16le('HwSystemSetupVers')
+	.string('SystemCode', 	{ encoding: 'ascii', length: 8 })
+	.string('SysName', 		{ encoding: 'ascii', length: 20 })
+	.string('AssetCode', 	{ encoding: 'ascii', length: 20 })
+	.uint8('AllowTechAuth') 		// boolean 0 = Off , 1 = On
+	.uint8('AllowQuickSession') 	// boolean 0 = Off , 1 = On
+	.uint32le('QuickSessionInterval', { formatter: (x) => {return x/1000;}})  // seconds
+	.int16le('SystemPresetId')
+	.int16le('SystemFirmwareVersion')
+	.int16le('SystemHardwareVersion')
+	.uint32le('SystemSerialNo')
 
-		return status.parse(msg);
-	}
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4a35_HwSystemSetup.js
+++ b/payload/Msg_4a35_HwSystemSetup.js
@@ -1,33 +1,30 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Hardware Configuration
-	// Object      = System
-	// MsgLength   = 76
-	// Description = System setup configuration
-	// Version     = 5
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid from  = SW 1.0.30
-	this.parse_4a35 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.int16le('HwSystemSetupVers')
-		.string('SystemCode', 	{ encoding: 'ascii', length: 8 })
-		.string('SysName', 		{ encoding: 'ascii', length: 20 })
-		.string('AssetCode', 	{ encoding: 'ascii', length: 20 })
-		.uint8('AllowTechAuth') 		// boolean 0 = Off , 1 = On
-		.uint8('AllowQuickSession') 	// boolean 0 = Off , 1 = On
-		.uint32le('QuickSessionInterval', { formatter: (x) => {return x/1000;}})  // seconds
-		.int16le('SystemPresetId')
-		.int16le('SystemFirmwareVersion')
-		.int16le('SystemHardwareVersion')
-		.uint32le('SystemSerialNo')
-		.uint8('ShowScheduler') 		// boolean 0 = Off , 1 = On
-		.uint8('ShowStripCycle') 		// boolean 0 = Off , 1 = On
-		
-		return status.parse(msg);
-	}
+// Category    = Hardware Configuration
+// Object      = System
+// MsgLength   = 76
+// Description = System setup configuration
+// Version     = 5
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid from  = SW 1.0.30
+const status = new Parser()
+	.skip(8)
+	.int16le('HwSystemSetupVers')
+	.string('SystemCode', 	{ encoding: 'ascii', length: 8 })
+	.string('SysName', 		{ encoding: 'ascii', length: 20 })
+	.string('AssetCode', 	{ encoding: 'ascii', length: 20 })
+	.uint8('AllowTechAuth') 		// boolean 0 = Off , 1 = On
+	.uint8('AllowQuickSession') 	// boolean 0 = Off , 1 = On
+	.uint32le('QuickSessionInterval', { formatter: (x) => {return x/1000;}})  // seconds
+	.int16le('SystemPresetId')
+	.int16le('SystemFirmwareVersion')
+	.int16le('SystemHardwareVersion')
+	.uint32le('SystemSerialNo')
+	.uint8('ShowScheduler') 		// boolean 0 = Off , 1 = On
+	.uint8('ShowStripCycle') 		// boolean 0 = Off , 1 = On
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4b34_HwCellGroupSetup.js
+++ b/payload/Msg_4b34_HwCellGroupSetup.js
@@ -1,65 +1,62 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
-	
-	// Category    = Hardware Configuration
-	// Object      = Cellmon
-	// MsgLength   = 51
-	// Description = Hardware cellmon setup configuration
-	// Version     = 4
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_4b34 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('HwCellmonSetupVers')  
-		.uint8('HwCellmonBattTypeID')  /* BattTypes
-				Custom 				= 0,
-				Li-FePO4 Typical 	= 1,
-				Li-Ion Performance 	= 2,
-				Li-Ion LongLife 	= 3, 
-				Li-FePO4 Longlife 	= 4, */
-		.uint8(  'HwCellmonFirstID')  
-		.uint8(  'HwCellmonLastID')  	
-		.int16le('HwCellmonNomCellVolt', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonLoCellVolt', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonHiCellVolt',			{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassVoltLevel',	{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassAmpLimit', 	{ formatter: (x) => {return x/1000;}})
-		.uint8( 'HwCellmonBypassTempLimit',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'HwCellmonLoCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'HwCellmonHiCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'HwCellmonDiffNomCellsInSeries')  	// Boolean 0 = Off , 1 = On
-		.uint8( 'HwCellmonNomCellsInSeries') 
-		.uint8( 'HwCellmonAllowEntireRange')  		// Boolean 0 = Off , 1 = On
-		.uint8( 'HwCellmonEntireFirstID')  
-		.uint8( 'HwCellmonEntireLastID')  
-		.uint8( 'HwCellmonBypassExtraMode')  /* BypassExtraModes
-				None 			= 0,
-				Idle Shunt 		= 1,
-				Same CellVolt 	= 2,
-				AutoLevel 		= 3, */
-		.int16le('HwCellmonBypassExtraInterval',		{ formatter: (x) => {return x/1000;}}) 	// seconds
-		.uint8(  'HwCellmonCellMonTypeID')  /* CellMonTypes
-				Custom 		= 0,
-				GenMon 2W 	= 1,
-				GenMon 8W 	= 2,
-				LongMon 	= 3,
-				BlockMonM8 	= 4,
-				BlockMonM14 = 5,
-				EndMon 		= 6,
-				ManyMon 	= 7, */
-		.floatle('HwCellmonBypassImpedance', 			{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassLoVoltCutout', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassShuntChargeLimit', 	{ formatter: (x) => {return x/100;}}) 	// amps
-		.int16le('HwCellmonBypassShuntDischgLimit', 	{ formatter: (x) => {return x/100;}}) 	// amps
-		.uint8(  'HwCellmonBypassShuntSocLo', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.int16le('HwCellmonBypassCellVoltBanding', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassCellVoltDiff', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassStableInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
+﻿const Parser = require('binary-parser').Parser;
 
-		return status.parse(msg);
-	}
+// Category    = Hardware Configuration
+// Object      = Cellmon
+// MsgLength   = 51
+// Description = Hardware cellmon setup configuration
+// Version     = 4
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('HwCellmonSetupVers')
+	.uint8('HwCellmonBattTypeID')  /* BattTypes
+			Custom 				= 0,
+			Li-FePO4 Typical 	= 1,
+			Li-Ion Performance 	= 2,
+			Li-Ion LongLife 	= 3,
+			Li-FePO4 Longlife 	= 4, */
+	.uint8(  'HwCellmonFirstID')
+	.uint8(  'HwCellmonLastID')
+	.int16le('HwCellmonNomCellVolt', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonLoCellVolt', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonHiCellVolt',			{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassVoltLevel',	{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassAmpLimit', 	{ formatter: (x) => {return x/1000;}})
+	.uint8( 'HwCellmonBypassTempLimit',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'HwCellmonLoCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'HwCellmonHiCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'HwCellmonDiffNomCellsInSeries')  	// Boolean 0 = Off , 1 = On
+	.uint8( 'HwCellmonNomCellsInSeries')
+	.uint8( 'HwCellmonAllowEntireRange')  		// Boolean 0 = Off , 1 = On
+	.uint8( 'HwCellmonEntireFirstID')
+	.uint8( 'HwCellmonEntireLastID')
+	.uint8( 'HwCellmonBypassExtraMode')  /* BypassExtraModes
+			None 			= 0,
+			Idle Shunt 		= 1,
+			Same CellVolt 	= 2,
+			AutoLevel 		= 3, */
+	.int16le('HwCellmonBypassExtraInterval',		{ formatter: (x) => {return x/1000;}}) 	// seconds
+	.uint8(  'HwCellmonCellMonTypeID')  /* CellMonTypes
+			Custom 		= 0,
+			GenMon 2W 	= 1,
+			GenMon 8W 	= 2,
+			LongMon 	= 3,
+			BlockMonM8 	= 4,
+			BlockMonM14 = 5,
+			EndMon 		= 6,
+			ManyMon 	= 7, */
+	.floatle('HwCellmonBypassImpedance', 			{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassLoVoltCutout', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassShuntChargeLimit', 	{ formatter: (x) => {return x/100;}}) 	// amps
+	.int16le('HwCellmonBypassShuntDischgLimit', 	{ formatter: (x) => {return x/100;}}) 	// amps
+	.uint8(  'HwCellmonBypassShuntSocLo', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.int16le('HwCellmonBypassCellVoltBanding', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassCellVoltDiff', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassStableInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4b35_HwCellGroupSetup.js
+++ b/payload/Msg_4b35_HwCellGroupSetup.js
@@ -1,66 +1,63 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
-	
-	// Category    = Hardware Configuration
-	// Object      = Cellmon
-	// MsgLength   = 53
-	// Description = Hardware cellmon setup configuration
-	// Version     = 5
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid from  = SW 1.0.30
-	this.parse_4b35 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('HwCellmonSetupVers')  
-		.uint8('HwCellmonBattTypeID')  /* BattTypes
-				Custom 				= 0,
-				Li-FePO4 Typical 	= 1,
-				Li-Ion Performance 	= 2,
-				Li-Ion LongLife 	= 3, 
-				Li-FePO4 Longlife 	= 4, */
-		.uint8(  'HwCellmonFirstID')  
-		.uint8(  'HwCellmonLastID')  	
-		.int16le('HwCellmonNomCellVolt', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonLoCellVolt', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonHiCellVolt',			{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassVoltLevel',	{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassAmpLimit', 	{ formatter: (x) => {return x/1000;}})
-		.uint8( 'HwCellmonBypassTempLimit',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'HwCellmonLoCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'HwCellmonHiCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'HwCellmonDiffNomCellsInSeries')  	// Boolean 0 = Off , 1 = On
-		.uint8( 'HwCellmonNomCellsInSeries') 
-		.uint8( 'HwCellmonAllowEntireRange')  		// Boolean 0 = Off , 1 = On
-		.uint8( 'HwCellmonEntireFirstID')  
-		.uint8( 'HwCellmonEntireLastID')  
-		.uint8( 'HwCellmonBypassExtraMode')  /* BypassExtraModes
-				None 			= 0,
-				Idle Shunt 		= 1,
-				Same CellVolt 	= 2,
-				AutoLevel 		= 3, */
-		.int16le('HwCellmonBypassExtraInterval',		{ formatter: (x) => {return x/1000;}}) 	// seconds
-		.uint8(  'HwCellmonCellMonTypeID')  /* CellMonTypes
-				Custom 		= 0,
-				GenMon 2W 	= 1,
-				GenMon 8W 	= 2,
-				LongMon 	= 3,
-				BlockMonM8 	= 4,
-				BlockMonM14 = 5,
-				EndMon 		= 6,
-				ManyMon 	= 7, */
-		.floatle('HwCellmonBypassImpedance', 			{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassLoVoltCutout', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassShuntChargeLimit', 	{ formatter: (x) => {return x/100;}}) 	// amps
-		.int16le('HwCellmonBypassShuntDischgLimit', 	{ formatter: (x) => {return x/100;}}) 	// amps
-		.uint8(  'HwCellmonBypassShuntSocLo', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.int16le('HwCellmonBypassCellVoltBanding', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassCellVoltDiff', 		{ formatter: (x) => {return x/1000;}})
-		.int16le('HwCellmonBypassStableInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
-		.int16le('HwCellmonBypassExtraAmpLimit', 		{ formatter: (x) => {return x/1000;}}) // amps
+﻿const Parser = require('binary-parser').Parser;
 
-		return status.parse(msg);
-	}
+// Category    = Hardware Configuration
+// Object      = Cellmon
+// MsgLength   = 53
+// Description = Hardware cellmon setup configuration
+// Version     = 5
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid from  = SW 1.0.30
+const status = new Parser()
+	.skip(8)
+	.uint8('HwCellmonSetupVers')
+	.uint8('HwCellmonBattTypeID')  /* BattTypes
+			Custom 				= 0,
+			Li-FePO4 Typical 	= 1,
+			Li-Ion Performance 	= 2,
+			Li-Ion LongLife 	= 3,
+			Li-FePO4 Longlife 	= 4, */
+	.uint8(  'HwCellmonFirstID')
+	.uint8(  'HwCellmonLastID')
+	.int16le('HwCellmonNomCellVolt', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonLoCellVolt', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonHiCellVolt',			{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassVoltLevel',	{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassAmpLimit', 	{ formatter: (x) => {return x/1000;}})
+	.uint8( 'HwCellmonBypassTempLimit',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'HwCellmonLoCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'HwCellmonHiCellTemp',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'HwCellmonDiffNomCellsInSeries')  	// Boolean 0 = Off , 1 = On
+	.uint8( 'HwCellmonNomCellsInSeries')
+	.uint8( 'HwCellmonAllowEntireRange')  		// Boolean 0 = Off , 1 = On
+	.uint8( 'HwCellmonEntireFirstID')
+	.uint8( 'HwCellmonEntireLastID')
+	.uint8( 'HwCellmonBypassExtraMode')  /* BypassExtraModes
+			None 			= 0,
+			Idle Shunt 		= 1,
+			Same CellVolt 	= 2,
+			AutoLevel 		= 3, */
+	.int16le('HwCellmonBypassExtraInterval',		{ formatter: (x) => {return x/1000;}}) 	// seconds
+	.uint8(  'HwCellmonCellMonTypeID')  /* CellMonTypes
+			Custom 		= 0,
+			GenMon 2W 	= 1,
+			GenMon 8W 	= 2,
+			LongMon 	= 3,
+			BlockMonM8 	= 4,
+			BlockMonM14 = 5,
+			EndMon 		= 6,
+			ManyMon 	= 7, */
+	.floatle('HwCellmonBypassImpedance', 			{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassLoVoltCutout', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassShuntChargeLimit', 	{ formatter: (x) => {return x/100;}}) 	// amps
+	.int16le('HwCellmonBypassShuntDischgLimit', 	{ formatter: (x) => {return x/100;}}) 	// amps
+	.uint8(  'HwCellmonBypassShuntSocLo', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.int16le('HwCellmonBypassCellVoltBanding', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassCellVoltDiff', 		{ formatter: (x) => {return x/1000;}})
+	.int16le('HwCellmonBypassStableInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
+	.int16le('HwCellmonBypassExtraAmpLimit', 		{ formatter: (x) => {return x/1000;}}) // amps
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4c33_HwShuntSetup.js
+++ b/payload/Msg_4c33_HwShuntSetup.js
@@ -1,53 +1,50 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
-	
-	// Category    = Hardware Configuration
-	// Object      = Shunt
-	// MsgLength   = 60
-	// Description = Hardware shunt setup configuration
-	// Version     = 3
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid from  = SW 1.0.30
-	this.parse_4c33 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('HwShuntShuntType')  /* ShuntTypes
-				None            				= 0,
-				SFP102MOD 100uOhm 375A 150V 	= 1, 
-				SFP101EVB 72uOhm 500A 150V     	= 2,
-				SFP101EVB 25uOhm 1500A 150V 	= 3,
-				SFP102MOD (4k) 375A 750V  		= 4, 
-				SFP102MOD (3k) 375A 600V   		= 5, 
-				SFP102MOD Negative volt sense  	= 6,
-				SFP102MOD 50uOhm 750A 150V 		= 7, 
-				ShuntMon2 50uOhm 500A 650V 		= 16, */
-		.int16le('HwShuntScale16volt')
-		.int16le('HwShuntScale16amp')
-		.int16le('HwShuntChargeIdle',	{ formatter: (x) => {return x/100;}})   // amps
-		.int16le('HwShuntDischgIdle',	{ formatter: (x) => {return x/100;}})	// amps
-		.uint8( 'HwShuntSocCountLo', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8( 'HwShuntSocCountHi', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8( 'HwShuntSocLoRecal', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8( 'HwShuntSocHiRecal', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8( 'HwShuntMonitorSocLoRecal') 	// boolean 0 = Off , 1 = On
-		.uint8( 'HwShuntMonitorSocHiRecal') 	// boolean 0 = Off , 1 = On
-		.uint8( 'HwShuntMonitorInBypassRecal')	// boolean 0 = Off , 1 = On
-		.floatle('HwShuntNomCapacity',	{ formatter: (x) => {return x/1000;}})	// Ah
-		.floatle('HwShuntGainVolt')
-		.floatle('HwShuntGainAmp')
-		.floatle('HwShuntGainAcculm')	// mAh
-		.floatle('HwShuntGainTemp') 	// temperature ºC
-		.uint8( 'HwShuntReverseFlow') 	// boolean 0 = Off , 1 = On
-		.uint8( 'HwShuntSetupVers') 
-		.floatle('HwShuntGainVA')
-		.floatle('HwShuntGainVAh')	
-		.int16le('HwShuntMax16volt')
-		.int16le('HwShuntMax16charge')
-		.int16le('HwShuntMax16dischg')
-		
-		return status.parse(msg);
-	}
+﻿const Parser = require('binary-parser').Parser;
+
+// Category    = Hardware Configuration
+// Object      = Shunt
+// MsgLength   = 60
+// Description = Hardware shunt setup configuration
+// Version     = 3
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid from  = SW 1.0.30
+const status = new Parser()
+	.skip(8)
+	.uint8('HwShuntShuntType')  /* ShuntTypes
+			None            				= 0,
+			SFP102MOD 100uOhm 375A 150V 	= 1,
+			SFP101EVB 72uOhm 500A 150V     	= 2,
+			SFP101EVB 25uOhm 1500A 150V 	= 3,
+			SFP102MOD (4k) 375A 750V  		= 4,
+			SFP102MOD (3k) 375A 600V   		= 5,
+			SFP102MOD Negative volt sense  	= 6,
+			SFP102MOD 50uOhm 750A 150V 		= 7,
+			ShuntMon2 50uOhm 500A 650V 		= 16, */
+	.int16le('HwShuntScale16volt')
+	.int16le('HwShuntScale16amp')
+	.int16le('HwShuntChargeIdle',	{ formatter: (x) => {return x/100;}})   // amps
+	.int16le('HwShuntDischgIdle',	{ formatter: (x) => {return x/100;}})	// amps
+	.uint8( 'HwShuntSocCountLo', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8( 'HwShuntSocCountHi', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8( 'HwShuntSocLoRecal', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8( 'HwShuntSocHiRecal', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8( 'HwShuntMonitorSocLoRecal') 	// boolean 0 = Off , 1 = On
+	.uint8( 'HwShuntMonitorSocHiRecal') 	// boolean 0 = Off , 1 = On
+	.uint8( 'HwShuntMonitorInBypassRecal')	// boolean 0 = Off , 1 = On
+	.floatle('HwShuntNomCapacity',	{ formatter: (x) => {return x/1000;}})	// Ah
+	.floatle('HwShuntGainVolt')
+	.floatle('HwShuntGainAmp')
+	.floatle('HwShuntGainAcculm')	// mAh
+	.floatle('HwShuntGainTemp') 	// temperature ºC
+	.uint8( 'HwShuntReverseFlow') 	// boolean 0 = Off , 1 = On
+	.uint8( 'HwShuntSetupVers')
+	.floatle('HwShuntGainVA')
+	.floatle('HwShuntGainVAh')
+	.int16le('HwShuntMax16volt')
+	.int16le('HwShuntMax16charge')
+	.int16le('HwShuntMax16dischg')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4c58_HwShuntSetup.js
+++ b/payload/Msg_4c58_HwShuntSetup.js
@@ -1,48 +1,45 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
-	
-	// Category    = Hardware Configuration
-	// Object      = Shunt
-	// MsgLength   = 46
-	// Description = Hardware shunt setup configuration
-	// Version     = 1
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_4c58 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('HwShuntShuntType')  /* ShuntTypes
-				None            				= 0,
-				SFP102MOD 100uOhm 375A 150V 	= 1, 
-				SFP101EVB 72uOhm 500A 150V     	= 2,
-				SFP101EVB 25uOhm 1500A 150V 	= 3,
-				SFP102MOD (4k) 375A 750V  		= 4, 
-				SFP102MOD (3k) 375A 600V   		= 5, 
-				SFP102MOD Negative volt sense  	= 6,
-				SFP102MOD 50uOhm 750A 150V 		= 7, 
-				ShuntMon2 50uOhm 500A 650V 		= 16, */
-		.int16le('HwShuntScale16volt')
-		.int16le('HwShuntScale16amp')
-		.int16le('HwShuntChargeIdle',	{ formatter: (x) => {return x/100;}})   // amps
-		.int16le('HwShuntDischgIdle',	{ formatter: (x) => {return x/100;}})	// amps
-		.uint8( 'HwShuntSocCountLo', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8( 'HwShuntSocCountHi', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8( 'HwShuntSocLoRecal', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8( 'HwShuntSocHiRecal', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8( 'HwShuntMonitorSocLoRecal') 	// boolean 0 = Off , 1 = On
-		.uint8( 'HwShuntMonitorSocHiRecal') 	// boolean 0 = Off , 1 = On
-		.uint8( 'HwShuntMonitorInBypassRecal')	// boolean 0 = Off , 1 = On
-		.floatle('HwShuntNomCapacity',	{ formatter: (x) => {return x/1000;}})	// Ah
-		.floatle('HwShuntGainVolt')
-		.floatle('HwShuntGainAmp')
-		.floatle('HwShuntGainAcculm')	// mAh
-		.floatle('HwShuntGainTemp') 	// temperature ºC
-		.uint8( 'HwShuntReverseFlow') 	// boolean 0 = Off , 1 = On
-		.uint8( 'HwShuntSetupVers') 	
+﻿const Parser = require('binary-parser').Parser;
 
-		return status.parse(msg);
-	}
+// Category    = Hardware Configuration
+// Object      = Shunt
+// MsgLength   = 46
+// Description = Hardware shunt setup configuration
+// Version     = 1
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('HwShuntShuntType')  /* ShuntTypes
+			None            				= 0,
+			SFP102MOD 100uOhm 375A 150V 	= 1,
+			SFP101EVB 72uOhm 500A 150V     	= 2,
+			SFP101EVB 25uOhm 1500A 150V 	= 3,
+			SFP102MOD (4k) 375A 750V  		= 4,
+			SFP102MOD (3k) 375A 600V   		= 5,
+			SFP102MOD Negative volt sense  	= 6,
+			SFP102MOD 50uOhm 750A 150V 		= 7,
+			ShuntMon2 50uOhm 500A 650V 		= 16, */
+	.int16le('HwShuntScale16volt')
+	.int16le('HwShuntScale16amp')
+	.int16le('HwShuntChargeIdle',	{ formatter: (x) => {return x/100;}})   // amps
+	.int16le('HwShuntDischgIdle',	{ formatter: (x) => {return x/100;}})	// amps
+	.uint8( 'HwShuntSocCountLo', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8( 'HwShuntSocCountHi', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8( 'HwShuntSocLoRecal', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8( 'HwShuntSocHiRecal', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8( 'HwShuntMonitorSocLoRecal') 	// boolean 0 = Off , 1 = On
+	.uint8( 'HwShuntMonitorSocHiRecal') 	// boolean 0 = Off , 1 = On
+	.uint8( 'HwShuntMonitorInBypassRecal')	// boolean 0 = Off , 1 = On
+	.floatle('HwShuntNomCapacity',	{ formatter: (x) => {return x/1000;}})	// Ah
+	.floatle('HwShuntGainVolt')
+	.floatle('HwShuntGainAmp')
+	.floatle('HwShuntGainAcculm')	// mAh
+	.floatle('HwShuntGainTemp') 	// temperature ºC
+	.uint8( 'HwShuntReverseFlow') 	// boolean 0 = Off , 1 = On
+	.uint8( 'HwShuntSetupVers')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4d33_HwExpansionSetup.js
+++ b/payload/Msg_4d33_HwExpansionSetup.js
@@ -1,72 +1,69 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
-	
-	// Category    = Hardware Configuration
-	// Object      = Expansion
-	// MsgLength   = 32
-	// Description = Hardware Expansion setup configuration
-	// Version     = 3
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_4d33 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('HwExpansionSetupVers')  
-		.uint8('HwExpansionTemplate')  /* ExtensionTemplateOptions
-				None = 0,
-				ExpansionBoard 12v = 1,
-				ExpansionBoard 48v = 2,
-				WatchMonCmC v2.0   = 3,	*/	
-		.uint8('HwExpansionNeoPixelMode')  /* NeoPixelExtStatusModes
-				None 				= 0,
-				Repeat 				= 1,
-				Status + 7seg SoC% 	= 2,
-				Solid SoC% 8seg 	= 3,	*/
-		.uint8('HwExpansionRelay1')  /* ExpansionOutputAssignments
-				None = 0,
-				ManualOn = 1,
-				Critical BattOk = 2,
-				Charging On = 4,
-				Discharging On = 5,
-				Heating Required = 6,
-				Cooling Required = 7,
-				Run / Idle input = 8,
-				Charge / Normal input = 9,
-				Bypass Complete = 10,
-				Charging Limited = 11,
-				Discharging Limited = 12,
-				Critical Recovery = 13,
-				Critical PulseOn = 14,
-				Critical PulseOff = 15,
-				Critical Fault = 16,
-				Critical PrechargeTimer = 17, */
-		.uint8('HwExpansionRelay2')  	/* ExpansionOutputAssignments */
-		.uint8('HwExpansionRelay3')  	/* ExpansionOutputAssignments */
-		.uint8('HwExpansionRelay4')		/* ExpansionOutputAssignments */
-		.uint8('HwExpansionOutput5')  	/* ExpansionOutputAssignments */
-		.uint8('HwExpansionOutput5')  	/* ExpansionOutputAssignments */
-		.uint8('HwExpansionOutput7')  	/* ExpansionOutputAssignments */
-		.uint8('HwExpansionOutput8')  	/* ExpansionOutputAssignments */
-		.uint8('HwExpansionOutput9')  	/* ExpansionOutputAssignments */
-		.uint8('HwExpansionOutput10') 	/* ExpansionOutputAssignments */
-		.uint8('HwExpansionInput1')  	/* ExtensionInputOptions
-				None 					= 0,
-				Run / Idle mode 		= 1,
-				Charge / Normal mode 	= 2,
-				Critical contact sensor - On = 3,
-				Critical contact sensor - Fault = 4, */
-		.uint8('HwExpansionInput2')  	/* ExtensionInputOptions */
-		.uint8('HwExpansionInput3')  	/* ExtensionInputOptions */
-		.uint8('HwExpansionInput4')  	/* ExtensionInputOptions */
-		.uint8('HwExpansionInput5')  	/* ExtensionInputOptions */
-		.uint8('HwExpansionInputAIN1') 
-		.uint8('HwExpansionInputAIN2') 
-		.int16le('HwExpansionCustomFeature1')
-		.int16le('HwExpansionCustomFeature2')
+﻿const Parser = require('binary-parser').Parser;
 
-		return status.parse(msg);
-	}
+// Category    = Hardware Configuration
+// Object      = Expansion
+// MsgLength   = 32
+// Description = Hardware Expansion setup configuration
+// Version     = 3
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('HwExpansionSetupVers')
+	.uint8('HwExpansionTemplate')  /* ExtensionTemplateOptions
+			None = 0,
+			ExpansionBoard 12v = 1,
+			ExpansionBoard 48v = 2,
+			WatchMonCmC v2.0   = 3,	*/
+	.uint8('HwExpansionNeoPixelMode')  /* NeoPixelExtStatusModes
+			None 				= 0,
+			Repeat 				= 1,
+			Status + 7seg SoC% 	= 2,
+			Solid SoC% 8seg 	= 3,	*/
+	.uint8('HwExpansionRelay1')  /* ExpansionOutputAssignments
+			None = 0,
+			ManualOn = 1,
+			Critical BattOk = 2,
+			Charging On = 4,
+			Discharging On = 5,
+			Heating Required = 6,
+			Cooling Required = 7,
+			Run / Idle input = 8,
+			Charge / Normal input = 9,
+			Bypass Complete = 10,
+			Charging Limited = 11,
+			Discharging Limited = 12,
+			Critical Recovery = 13,
+			Critical PulseOn = 14,
+			Critical PulseOff = 15,
+			Critical Fault = 16,
+			Critical PrechargeTimer = 17, */
+	.uint8('HwExpansionRelay2')  	/* ExpansionOutputAssignments */
+	.uint8('HwExpansionRelay3')  	/* ExpansionOutputAssignments */
+	.uint8('HwExpansionRelay4')		/* ExpansionOutputAssignments */
+	.uint8('HwExpansionOutput5')  	/* ExpansionOutputAssignments */
+	.uint8('HwExpansionOutput5')  	/* ExpansionOutputAssignments */
+	.uint8('HwExpansionOutput7')  	/* ExpansionOutputAssignments */
+	.uint8('HwExpansionOutput8')  	/* ExpansionOutputAssignments */
+	.uint8('HwExpansionOutput9')  	/* ExpansionOutputAssignments */
+	.uint8('HwExpansionOutput10') 	/* ExpansionOutputAssignments */
+	.uint8('HwExpansionInput1')  	/* ExtensionInputOptions
+			None 					= 0,
+			Run / Idle mode 		= 1,
+			Charge / Normal mode 	= 2,
+			Critical contact sensor - On = 3,
+			Critical contact sensor - Fault = 4, */
+	.uint8('HwExpansionInput2')  	/* ExtensionInputOptions */
+	.uint8('HwExpansionInput3')  	/* ExtensionInputOptions */
+	.uint8('HwExpansionInput4')  	/* ExtensionInputOptions */
+	.uint8('HwExpansionInput5')  	/* ExtensionInputOptions */
+	.uint8('HwExpansionInputAIN1')
+	.uint8('HwExpansionInputAIN2')
+	.int16le('HwExpansionCustomFeature1')
+	.int16le('HwExpansionCustomFeature2')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4e58_ControlRemoteSetup.js
+++ b/payload/Msg_4e58_ControlRemoteSetup.js
@@ -1,39 +1,36 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Control Configuration
-	// Object      = Remote
-	// MsgLength   = 45
-	// Description = Control remote setup configuration
-	// Version     = 1
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_4e58 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.int16le('ControlChargeTargetNormVolt')
-		.int16le('ControlChargeTargetNormAmp')
-		.int16le('ControlChargeTargetNormVA')
-		.int16le('ControlChargeTargetLimpVolt')
-		.int16le('ControlChargeTargetLimpAmp')
-		.int16le('ControlChargeTargetLimpVA')
-		.int16le('ControlChargeScale16volt')
-		.int16le('ControlChargeScale16amp')
-		.int16le('ControlChargeScale16va')
-		.int16le('ControlDischargeTargetNormVolt')
-		.int16le('ControlDischargeTargetNormAmp')
-		.int16le('ControlDischargeTargetNormVA')
-		.int16le('ControlDischargeTargetLimpVolt')
-		.int16le('ControlDischargeTargetLimpAmp')
-		.int16le('ControlDischargeTargetLimpVA')
-		.int16le('ControlDischargeScale16volt')
-		.int16le('ControlDischargeScale16amp')
-		.int16le('ControlDischargeScale16va')
-		.uint8('ControlRemoteSetupVers')  
-		
-		return status.parse(msg);
-	}
+// Category    = Control Configuration
+// Object      = Remote
+// MsgLength   = 45
+// Description = Control remote setup configuration
+// Version     = 1
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.int16le('ControlChargeTargetNormVolt')
+	.int16le('ControlChargeTargetNormAmp')
+	.int16le('ControlChargeTargetNormVA')
+	.int16le('ControlChargeTargetLimpVolt')
+	.int16le('ControlChargeTargetLimpAmp')
+	.int16le('ControlChargeTargetLimpVA')
+	.int16le('ControlChargeScale16volt')
+	.int16le('ControlChargeScale16amp')
+	.int16le('ControlChargeScale16va')
+	.int16le('ControlDischargeTargetNormVolt')
+	.int16le('ControlDischargeTargetNormAmp')
+	.int16le('ControlDischargeTargetNormVA')
+	.int16le('ControlDischargeTargetLimpVolt')
+	.int16le('ControlDischargeTargetLimpAmp')
+	.int16le('ControlDischargeTargetLimpVA')
+	.int16le('ControlDischargeScale16volt')
+	.int16le('ControlDischargeScale16amp')
+	.int16le('ControlDischargeScale16va')
+	.uint8('ControlRemoteSetupVers')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_4f33_ControlCriticalSetup.js
+++ b/payload/Msg_4f33_ControlCriticalSetup.js
@@ -1,64 +1,61 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Control Configuration
-	// Object      = Critical
-	// MsgLength   = 75
-	// Description = Control Critical setup configuration
-	// Version     = 3
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_4f33 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8( 'ControlCriticalMode')   /* Choices ControlCriticalModes
-				Auto 			= 0,
-				Manually On 	= 1,
-				Manually Off  	= 2, */	
-		.uint8( 'ControlCriticalAutoRecovery')  			// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalIgnoreCellsOverdue') 		// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalMonitorCellVoltLo') 		// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalMonitorCellVoltHi') 		// boolean 0 = Off , 1 = On
-		.int16le('ControlCriticalCellVoltLo',				{ formatter: (x) => {return x/1000;}})
-		.int16le('ControlCriticalCellVoltHi',				{ formatter: (x) => {return x/1000;}})
-		.uint8( 'ControlCriticalMonitorCellTempLo') 		// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalMonitorCellTempHi') 		// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalCellTempLo',				{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'ControlCriticalCellTempHi',				{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'ControlCriticalMonitorSupplyLo') 			// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalMonitorSupplyHi') 			// boolean 0 = Off , 1 = On
-		.int16le('ControlCriticalSupplyVoltLo',				{ formatter: (x) => {return x/100;}})
-		.int16le('ControlCriticalSupplyVoltHi',				{ formatter: (x) => {return x/100;}})
-		.uint8( 'ControlCriticalMonitorAmbientLo') 			// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalMonitorAmbientHi') 			// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalAmbientTempLo',				{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'ControlCriticalAmbientTempHi',				{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8( 'ControlCriticalMonitorShuntVoltLo') 		// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalMonitorShuntVoltHi') 		// boolean 0 = Off , 1 = On
-		.uint8( 'ControlCriticalMonitorShuntVoltLoIdle') 	// boolean 0 = Off , 1 = On
-		.int16le('ControlCriticalShuntVoltLo',				{ formatter: (x) => {return x/100;}})
-		.int16le('ControlCriticalShuntVoltHi',				{ formatter: (x) => {return x/100;}})
-		.int16le('ControlCriticalShuntVoltLoIdle',			{ formatter: (x) => {return x/100;}})
-		.uint8(  'ControlCriticalMonitorShuntPeakCharge') 	// boolean 0 = Off , 1 = On
-		.int16le('ControlCriticalShuntPeakCharge',			{ formatter: (x) => {return x/100;}}) // amps
-		.int16le('ControlCriticalShuntCrateCharge',			{ formatter: (x) => {return x/100;}}) // ratio
-		.uint8(  'ControlCriticalMonitorShuntPeakDischg') 	// boolean 0 = Off , 1 = On
-		.int16le('ControlCriticalShuntPeakDischg',			{ formatter: (x) => {return x/100;}}) // amps
-		.int16le('ControlCriticalShuntCrateDischg',			{ formatter: (x) => {return x/100;}}) // ratio
-		.uint32le('ControlCriticalStopInterval',			{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint32le('ControlCriticalStartInterval',			{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint32le('ControlCriticalTimeoutManualOverride',	{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint32le('ControlCriticalPrechargeTimeInterval',	{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint8(  'ControlCriticalIgnoreShuntOverdue') 		// boolean 0 = Off , 1 = On
-		.uint8(  'ControlCriticalIgnoreRemoteOverdue') 		// boolean 0 = Off , 1 = On
-		.int16le('ControlCriticalRecoverSupplyGapVolt',		{ formatter: (x) => {return x/100;}})
-		.int16le('ControlCriticalRecoverShuntChargeLimit',	{ formatter: (x) => {return x/100;}}) // amps
-		.int16le('ControlCriticalRecoverShuntDischgLimit',	{ formatter: (x) => {return x/100;}}) // amps
-		.uint8(  'ControlCriticalSetupVers') 
-		
-		return status.parse(msg);
-	}
+// Category    = Control Configuration
+// Object      = Critical
+// MsgLength   = 75
+// Description = Control Critical setup configuration
+// Version     = 3
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8( 'ControlCriticalMode')   /* Choices ControlCriticalModes
+			Auto 			= 0,
+			Manually On 	= 1,
+			Manually Off  	= 2, */
+	.uint8( 'ControlCriticalAutoRecovery')  			// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalIgnoreCellsOverdue') 		// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalMonitorCellVoltLo') 		// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalMonitorCellVoltHi') 		// boolean 0 = Off , 1 = On
+	.int16le('ControlCriticalCellVoltLo',				{ formatter: (x) => {return x/1000;}})
+	.int16le('ControlCriticalCellVoltHi',				{ formatter: (x) => {return x/1000;}})
+	.uint8( 'ControlCriticalMonitorCellTempLo') 		// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalMonitorCellTempHi') 		// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalCellTempLo',				{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'ControlCriticalCellTempHi',				{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'ControlCriticalMonitorSupplyLo') 			// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalMonitorSupplyHi') 			// boolean 0 = Off , 1 = On
+	.int16le('ControlCriticalSupplyVoltLo',				{ formatter: (x) => {return x/100;}})
+	.int16le('ControlCriticalSupplyVoltHi',				{ formatter: (x) => {return x/100;}})
+	.uint8( 'ControlCriticalMonitorAmbientLo') 			// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalMonitorAmbientHi') 			// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalAmbientTempLo',				{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'ControlCriticalAmbientTempHi',				{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8( 'ControlCriticalMonitorShuntVoltLo') 		// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalMonitorShuntVoltHi') 		// boolean 0 = Off , 1 = On
+	.uint8( 'ControlCriticalMonitorShuntVoltLoIdle') 	// boolean 0 = Off , 1 = On
+	.int16le('ControlCriticalShuntVoltLo',				{ formatter: (x) => {return x/100;}})
+	.int16le('ControlCriticalShuntVoltHi',				{ formatter: (x) => {return x/100;}})
+	.int16le('ControlCriticalShuntVoltLoIdle',			{ formatter: (x) => {return x/100;}})
+	.uint8(  'ControlCriticalMonitorShuntPeakCharge') 	// boolean 0 = Off , 1 = On
+	.int16le('ControlCriticalShuntPeakCharge',			{ formatter: (x) => {return x/100;}}) // amps
+	.int16le('ControlCriticalShuntCrateCharge',			{ formatter: (x) => {return x/100;}}) // ratio
+	.uint8(  'ControlCriticalMonitorShuntPeakDischg') 	// boolean 0 = Off , 1 = On
+	.int16le('ControlCriticalShuntPeakDischg',			{ formatter: (x) => {return x/100;}}) // amps
+	.int16le('ControlCriticalShuntCrateDischg',			{ formatter: (x) => {return x/100;}}) // ratio
+	.uint32le('ControlCriticalStopInterval',			{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint32le('ControlCriticalStartInterval',			{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint32le('ControlCriticalTimeoutManualOverride',	{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint32le('ControlCriticalPrechargeTimeInterval',	{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint8(  'ControlCriticalIgnoreShuntOverdue') 		// boolean 0 = Off , 1 = On
+	.uint8(  'ControlCriticalIgnoreRemoteOverdue') 		// boolean 0 = Off , 1 = On
+	.int16le('ControlCriticalRecoverSupplyGapVolt',		{ formatter: (x) => {return x/100;}})
+	.int16le('ControlCriticalRecoverShuntChargeLimit',	{ formatter: (x) => {return x/100;}}) // amps
+	.int16le('ControlCriticalRecoverShuntDischgLimit',	{ formatter: (x) => {return x/100;}}) // amps
+	.uint8(  'ControlCriticalSetupVers')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_5033_ControlChargeSetup.js
+++ b/payload/Msg_5033_ControlChargeSetup.js
@@ -1,57 +1,54 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Control Configuration
-	// Object      = Charge
-	// MsgLength   = 60
-	// Description = Control Charging setup configuration
-	// Version     = 3
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_5033 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8( 'ControlChargeMode')  /* Choices ControlChargeModes
-				Auto		  	 = 0,
-				Manually On      = 1,
-				Manually Off     = 2,
-				Manually Limited = 3, */	
-		.uint8(  'ControlChargeAllowLimPowerStage')  	// boolean 0 = Off , 1 = On
-		.uint8(  'ControlChargeAllowBypassLimPower') 	// boolean 0 = Off , 1 = On
-		.uint8(  'ControlChargeAllowBypassComplete') 	// boolean 0 = Off , 1 = On
-		.int16le('ControlChargeInitalBypassAmp',		{ formatter: (x) => {return x/1000;}})
-		.int16le('ControlChargeFinalBypassAmp',			{ formatter: (x) => {return x/1000;}})
-		.uint8(  'ControlChargeMonitorCellTempLo') 		// boolean 0 = Off , 1 = On
-		.uint8(  'ControlChargeMonitorCellTempHi') 		// boolean 0 = Off , 1 = On
-		.uint8(  'ControlChargeCellTempLo',				{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8(  'ControlChargeCellTempHi',				{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8(  'ControlChargeMonitorAmbientLo') 		// boolean 0 = Off , 1 = On
-		.uint8(  'ControlChargeMonitorAmbientHi') 		// boolean 0 = Off , 1 = On
-		.uint8(  'ControlChargeAmbientTempLo',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8(  'ControlChargeAmbientTempHi',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8(  'ControlChargeMonitorSupplyHi') 		// boolean 0 = Off , 1 = On
-		.int16le('ControlChargeSupplyVoltHi',			{ formatter: (x) => {return x/100;}})
-		.int16le('ControlChargeSupplyVoltResume',		{ formatter: (x) => {return x/100;}})
-		.uint8(  'ControlChargeMonitorCellVoltHi') 		// boolean 0 = Off , 1 = On
-		.int16le('ControlChargeCellVoltHi',				{ formatter: (x) => {return x/1000;}})
-		.int16le('ControlChargeCellVoltResume',			{ formatter: (x) => {return x/1000;}})
-		.int16le('ControlChargeCellVoltLimPower',		{ formatter: (x) => {return x/1000;}})
-		.uint8(  'ControlChargeMonitorShuntVoltHi') 	// boolean 0 = Off , 1 = On
-		.int16le('ControlChargeShuntVoltHi',			{ formatter: (x) => {return x/100;}})
-		.int16le('ControlChargeShuntVoltResume',		{ formatter: (x) => {return x/100;}})
-		.int16le('ControlChargeShuntVoltLimPower',		{ formatter: (x) => {return x/100;}})
-		.uint8(  'ControlChargeMonitorShuntSocHi') 		// boolean 0 = Off , 1 = On
-		.uint8(  'ControlChargeShuntSocHi', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8(  'ControlChargeShuntSocResume', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint32le('ControlChargeStopInterval',			{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint32le('ControlChargeStartInterval',			{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint8(  'ControlChargeSetupVers')  
-		.floatle('ControlChargeBypassSessionLo',		{ formatter: (x) => {return x/1000;}})	// Ah
-		.uint8(  'ControlChargeAllowBypassSession') 	// boolean 0 = Off , 1 = On
-		
-		return status.parse(msg);
-	}
+// Category    = Control Configuration
+// Object      = Charge
+// MsgLength   = 60
+// Description = Control Charging setup configuration
+// Version     = 3
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8( 'ControlChargeMode')  /* Choices ControlChargeModes
+			Auto		  	 = 0,
+			Manually On      = 1,
+			Manually Off     = 2,
+			Manually Limited = 3, */
+	.uint8(  'ControlChargeAllowLimPowerStage')  	// boolean 0 = Off , 1 = On
+	.uint8(  'ControlChargeAllowBypassLimPower') 	// boolean 0 = Off , 1 = On
+	.uint8(  'ControlChargeAllowBypassComplete') 	// boolean 0 = Off , 1 = On
+	.int16le('ControlChargeInitalBypassAmp',		{ formatter: (x) => {return x/1000;}})
+	.int16le('ControlChargeFinalBypassAmp',			{ formatter: (x) => {return x/1000;}})
+	.uint8(  'ControlChargeMonitorCellTempLo') 		// boolean 0 = Off , 1 = On
+	.uint8(  'ControlChargeMonitorCellTempHi') 		// boolean 0 = Off , 1 = On
+	.uint8(  'ControlChargeCellTempLo',				{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8(  'ControlChargeCellTempHi',				{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8(  'ControlChargeMonitorAmbientLo') 		// boolean 0 = Off , 1 = On
+	.uint8(  'ControlChargeMonitorAmbientHi') 		// boolean 0 = Off , 1 = On
+	.uint8(  'ControlChargeAmbientTempLo',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8(  'ControlChargeAmbientTempHi',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8(  'ControlChargeMonitorSupplyHi') 		// boolean 0 = Off , 1 = On
+	.int16le('ControlChargeSupplyVoltHi',			{ formatter: (x) => {return x/100;}})
+	.int16le('ControlChargeSupplyVoltResume',		{ formatter: (x) => {return x/100;}})
+	.uint8(  'ControlChargeMonitorCellVoltHi') 		// boolean 0 = Off , 1 = On
+	.int16le('ControlChargeCellVoltHi',				{ formatter: (x) => {return x/1000;}})
+	.int16le('ControlChargeCellVoltResume',			{ formatter: (x) => {return x/1000;}})
+	.int16le('ControlChargeCellVoltLimPower',		{ formatter: (x) => {return x/1000;}})
+	.uint8(  'ControlChargeMonitorShuntVoltHi') 	// boolean 0 = Off , 1 = On
+	.int16le('ControlChargeShuntVoltHi',			{ formatter: (x) => {return x/100;}})
+	.int16le('ControlChargeShuntVoltResume',		{ formatter: (x) => {return x/100;}})
+	.int16le('ControlChargeShuntVoltLimPower',		{ formatter: (x) => {return x/100;}})
+	.uint8(  'ControlChargeMonitorShuntSocHi') 		// boolean 0 = Off , 1 = On
+	.uint8(  'ControlChargeShuntSocHi', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8(  'ControlChargeShuntSocResume', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint32le('ControlChargeStopInterval',			{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint32le('ControlChargeStartInterval',			{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint8(  'ControlChargeSetupVers')
+	.floatle('ControlChargeBypassSessionLo',		{ formatter: (x) => {return x/1000;}})	// Ah
+	.uint8(  'ControlChargeAllowBypassSession') 	// boolean 0 = Off , 1 = On
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_5158_ControlDischargeSetup.js
+++ b/payload/Msg_5158_ControlDischargeSetup.js
@@ -1,51 +1,48 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Control Configuration
-	// Object      = Discharge
-	// MsgLength   = 49
-	// Description = Control Discharge setup configuration
-	// Version     = 1
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_5158 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8(   'ControlDischargeMode') /* Choices ControlDischgModes
-				Auto		  	 = 0,
-				Manually On      = 1,
-				Manually Off     = 2,
-				Manually Limited = 3, */	
-		.uint8(   'ControlDischargeAllowLimPowerStage')	// boolean 0 = Off , 1 = On
-		.uint8(   'ControlDischargeMonitorCellTempLo') 	// boolean 0 = Off , 1 = On
-		.uint8(   'ControlDischargeMonitorCellTempHi') 	// boolean 0 = Off , 1 = On
-		.uint8(   'ControlDischargeCellTempLo',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8(   'ControlDischargeCellTempHi',			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8(   'ControlDischargeMonitorAmbientLo') 	// boolean 0 = Off , 1 = On
-		.uint8(   'ControlDischargeMonitorAmbientHi') 	// boolean 0 = Off , 1 = On
-		.uint8(   'ControlDischargeAmbientTempLo',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8(   'ControlDischargeAmbientTempHi',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8(   'ControlDischargeMonitorSupplyLo') 	// boolean 0 = Off , 1 = On
-		.int16le( 'ControlDischargeSupplyVoltLo',		{ formatter: (x) => {return x/100;}})
-		.int16le( 'ControlDischargeSupplyVoltResume',	{ formatter: (x) => {return x/100;}})
-		.uint8(   'ControlDischargeMonitorCellVoltLo') 	// boolean 0 = Off , 1 = On
-		.int16le( 'ControlDischargeCellVoltLo',			{ formatter: (x) => {return x/1000;}})
-		.int16le( 'ControlDischargeCellVoltResume',		{ formatter: (x) => {return x/1000;}})
-		.int16le( 'ControlDischargeCellVoltLimPower',	{ formatter: (x) => {return x/1000;}})
-		.uint8(   'ControlDischargeMonitorShuntVoltLo') // boolean 0 = Off , 1 = On
-		.int16le( 'ControlDischargeShuntVoltLo',		{ formatter: (x) => {return x/100;}})
-		.int16le( 'ControlDischargeShuntVoltResume',	{ formatter: (x) => {return x/100;}})
-		.int16le( 'ControlDischargeShuntVoltLimPower',	{ formatter: (x) => {return x/100;}})
-		.uint8(   'ControlDischargeMonitorShuntSocLo') 	// boolean 0 = Off , 1 = On
-		.uint8(   'ControlDischargeShuntSocLo', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8(   'ControlDischargeShuntSocResume', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint32le('ControlDischargeStopInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint32le('ControlDischargeStartInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint8(   'ControlDischargeSetupVers')  
-		
-		return status.parse(msg);
-	}
+// Category    = Control Configuration
+// Object      = Discharge
+// MsgLength   = 49
+// Description = Control Discharge setup configuration
+// Version     = 1
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8(   'ControlDischargeMode') /* Choices ControlDischgModes
+			Auto		  	 = 0,
+			Manually On      = 1,
+			Manually Off     = 2,
+			Manually Limited = 3, */
+	.uint8(   'ControlDischargeAllowLimPowerStage')	// boolean 0 = Off , 1 = On
+	.uint8(   'ControlDischargeMonitorCellTempLo') 	// boolean 0 = Off , 1 = On
+	.uint8(   'ControlDischargeMonitorCellTempHi') 	// boolean 0 = Off , 1 = On
+	.uint8(   'ControlDischargeCellTempLo',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8(   'ControlDischargeCellTempHi',			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8(   'ControlDischargeMonitorAmbientLo') 	// boolean 0 = Off , 1 = On
+	.uint8(   'ControlDischargeMonitorAmbientHi') 	// boolean 0 = Off , 1 = On
+	.uint8(   'ControlDischargeAmbientTempLo',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8(   'ControlDischargeAmbientTempHi',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8(   'ControlDischargeMonitorSupplyLo') 	// boolean 0 = Off , 1 = On
+	.int16le( 'ControlDischargeSupplyVoltLo',		{ formatter: (x) => {return x/100;}})
+	.int16le( 'ControlDischargeSupplyVoltResume',	{ formatter: (x) => {return x/100;}})
+	.uint8(   'ControlDischargeMonitorCellVoltLo') 	// boolean 0 = Off , 1 = On
+	.int16le( 'ControlDischargeCellVoltLo',			{ formatter: (x) => {return x/1000;}})
+	.int16le( 'ControlDischargeCellVoltResume',		{ formatter: (x) => {return x/1000;}})
+	.int16le( 'ControlDischargeCellVoltLimPower',	{ formatter: (x) => {return x/1000;}})
+	.uint8(   'ControlDischargeMonitorShuntVoltLo') // boolean 0 = Off , 1 = On
+	.int16le( 'ControlDischargeShuntVoltLo',		{ formatter: (x) => {return x/100;}})
+	.int16le( 'ControlDischargeShuntVoltResume',	{ formatter: (x) => {return x/100;}})
+	.int16le( 'ControlDischargeShuntVoltLimPower',	{ formatter: (x) => {return x/100;}})
+	.uint8(   'ControlDischargeMonitorShuntSocLo') 	// boolean 0 = Off , 1 = On
+	.uint8(   'ControlDischargeShuntSocLo', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8(   'ControlDischargeShuntSocResume', 	{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint32le('ControlDischargeStopInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint32le('ControlDischargeStartInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint8(   'ControlDischargeSetupVers')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_5258_ControlThermalSetup.js
+++ b/payload/Msg_5258_ControlThermalSetup.js
@@ -1,39 +1,36 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Control Configuration
-	// Object      = Thermal
-	// MsgLength   = 36
-	// Description = Control thermal setup configuration
-	// Version     = 1
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_5258 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('ControlHeatMode')  /* Choices ThermalControlModes
-				Auto		  	 = 0,
-				Manually On      = 1,
-				Manually Off     = 2, */	
-		.uint8('ControlHeatMonitorLoCellTemp')  	// Boolean 0 = Off , 1 = On
-		.uint8('ControlHeatMonitorLoAmbient')  		// Boolean 0 = Off , 1 = On
-		.uint8('ControlHeatLoCellTemp', 			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('ControlHeatLoAmbient',	 			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint32le('ControlHeatStopInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint32le('ControlHeatStartInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint8('ControlCoolMode')  					/* Choices ThermalControlModes */
-		.uint8('ControlCoolMonitorHiCellTemp')  	// Boolean 0 = Off , 1 = On
-		.uint8('ControlCoolMonitorHiAmbient')   	// Boolean 0 = Off , 1 = On
-		.uint8('ControlCoolMonitorInBypass')   		// Boolean 0 = Off , 1 = On
-		.uint8('ControlCoolHiCellTemp', 			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('ControlCoolHiAmbient',	 			{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint32le('ControlCoolStopInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint32le('ControlCoolStartInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
-		.uint8('ControlThermalSetupVers')  
+// Category    = Control Configuration
+// Object      = Thermal
+// MsgLength   = 36
+// Description = Control thermal setup configuration
+// Version     = 1
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('ControlHeatMode')  /* Choices ThermalControlModes
+			Auto		  	 = 0,
+			Manually On      = 1,
+			Manually Off     = 2, */
+	.uint8('ControlHeatMonitorLoCellTemp')  	// Boolean 0 = Off , 1 = On
+	.uint8('ControlHeatMonitorLoAmbient')  		// Boolean 0 = Off , 1 = On
+	.uint8('ControlHeatLoCellTemp', 			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('ControlHeatLoAmbient',	 			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint32le('ControlHeatStopInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint32le('ControlHeatStartInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint8('ControlCoolMode')  					/* Choices ThermalControlModes */
+	.uint8('ControlCoolMonitorHiCellTemp')  	// Boolean 0 = Off , 1 = On
+	.uint8('ControlCoolMonitorHiAmbient')   	// Boolean 0 = Off , 1 = On
+	.uint8('ControlCoolMonitorInBypass')   		// Boolean 0 = Off , 1 = On
+	.uint8('ControlCoolHiCellTemp', 			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('ControlCoolHiAmbient',	 			{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint32le('ControlCoolStopInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint32le('ControlCoolStartInterval',		{ formatter: (x) => {return x/1000;}}) // seconds
+	.uint8('ControlThermalSetupVers')
 
-		return status.parse(msg);
-	}
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_5334_HwIntegrationSetup.js
+++ b/payload/Msg_5334_HwIntegrationSetup.js
@@ -1,47 +1,44 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Hardware Configuration
-	// Object      = Integration
-	// MsgLength   = 26
-	// Description = Hardware Integration setup configuration
-	// Version     = 4
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_5334 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('HwIntegrationSetupVers')  
-		.uint8('HwIntegrationUsbTxBroadcast')  		// boolean 0 = Off , 1 = On
-		.uint8('HwIntegrationWifiUdpTxBroadcast') 	// boolean 0 = Off , 1 = On
-		.uint8('HwIntegrationWifiBroadcastMode') /* WifiBroadcastModes
-				None 		= 0,
-				Verbose 	= 1,
-				Verbose ReadOnly = 4,
-				Limited 	= 2,
-				Disabled 	= 3, */
-		.uint8('HwIntegrationCanbusTxBroadcast') 	// boolean 0 = Off , 1 = On
-		.uint8('HwIntegrationCanbusMode') /* CanbusModes
-				None   		= 0,
-				Native 		= 1,
-				Elcon TCCharger = 2,
-				EnPower Charger500k = 3,
-				Solax PowerSK control = 4,
-				Sma SunnyIsland V31 = 5,
-				Brusa NLG5 	= 6,
-				EnPower Charger 250k = 7,
-				Solax PowerSK Limited = 8,
-				Brusa NLG6 	= 9,
-				Project Lychee = 10,
-				Eltek FlatPack2 HE2000/48 = 11,
-				Project42 	= 42,	*/
-		.uint32le('HwIntegrationCanbusRemoteAddr')
-		.uint32le('HwIntegrationCanbusBaseAddr')
-		.uint32le('HwIntegrationCanbusGroupAddr')
-		
-		return status.parse(msg);
-	}
+// Category    = Hardware Configuration
+// Object      = Integration
+// MsgLength   = 26
+// Description = Hardware Integration setup configuration
+// Version     = 4
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('HwIntegrationSetupVers')
+	.uint8('HwIntegrationUsbTxBroadcast')  		// boolean 0 = Off , 1 = On
+	.uint8('HwIntegrationWifiUdpTxBroadcast') 	// boolean 0 = Off , 1 = On
+	.uint8('HwIntegrationWifiBroadcastMode') /* WifiBroadcastModes
+			None 		= 0,
+			Verbose 	= 1,
+			Verbose ReadOnly = 4,
+			Limited 	= 2,
+			Disabled 	= 3, */
+	.uint8('HwIntegrationCanbusTxBroadcast') 	// boolean 0 = Off , 1 = On
+	.uint8('HwIntegrationCanbusMode') /* CanbusModes
+			None   		= 0,
+			Native 		= 1,
+			Elcon TCCharger = 2,
+			EnPower Charger500k = 3,
+			Solax PowerSK control = 4,
+			Sma SunnyIsland V31 = 5,
+			Brusa NLG5 	= 6,
+			EnPower Charger 250k = 7,
+			Solax PowerSK Limited = 8,
+			Brusa NLG6 	= 9,
+			Project Lychee = 10,
+			Eltek FlatPack2 HE2000/48 = 11,
+			Project42 	= 42,	*/
+	.uint32le('HwIntegrationCanbusRemoteAddr')
+	.uint32le('HwIntegrationCanbusBaseAddr')
+	.uint32le('HwIntegrationCanbusGroupAddr')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_5431_SessionMetrics.js
+++ b/payload/Msg_5431_SessionMetrics.js
@@ -1,27 +1,24 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Telemetry Metrics
-	// Object      = Session
-	// MsgLength   = 25
-	// Description = Telemetry Session metrics
-	// Version     = 1
-	// Frequency   = adhoc
-	// Support     = Current
-	// Created    	= SW 1.0.29
-	this.parse_5431 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint32le('QuickSessRecentTime') 		// EPOCH
-		.int16le('QuickSessNumOfRecords')
-		.int16le('QuickSessMaxNumOfRecords')
-		.uint32le('QuickSessionInterval',		{ formatter: (x) => {return x/1000;}})
-		.uint8('AllowQuickSession')  			// boolean 0 = Off , 1 = On
-		.int16le('DailySessNumOfRecords')
-		.int16le('DailySessMaxNumOfRecords')
+// Category    = Telemetry Metrics
+// Object      = Session
+// MsgLength   = 25
+// Description = Telemetry Session metrics
+// Version     = 1
+// Frequency   = adhoc
+// Support     = Current
+// Created    	= SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint32le('QuickSessRecentTime') 		// EPOCH
+	.int16le('QuickSessNumOfRecords')
+	.int16le('QuickSessMaxNumOfRecords')
+	.uint32le('QuickSessionInterval',		{ formatter: (x) => {return x/1000;}})
+	.uint8('AllowQuickSession')  			// boolean 0 = Off , 1 = On
+	.int16le('DailySessNumOfRecords')
+	.int16le('DailySessMaxNumOfRecords')
 
-		return status.parse(msg);
-	}
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_5432_DailySession.js
+++ b/payload/Msg_5432_DailySession.js
@@ -1,55 +1,52 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Telemetry 
-	// Object      = Daily Session
-	// MsgLength   = 69
-	// Description = Daily session today in progress calc
-	// Version     = 2
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid from  = SW 1.0.30
-	this.parse_5432 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.int16le('DailySessionMinCellVolt',		{ formatter: (x) => {return x/1000;}})
-		.int16le('DailySessionMaxCellVolt',		{ formatter: (x) => {return x/1000;}})
-		.int16le('DailySessionMinSupplyVolt',	{ formatter: (x) => {return x/100;}})
-		.int16le('DailySessionMaxSupplyVolt',	{ formatter: (x) => {return x/100;}})
-		.uint8('DailySessionMinReportTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('DailySessionMaxReportTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.int16le('DailySessionMinShuntVolt',	{ formatter: (x) => {return x/100;}})
-		.int16le('DailySessionMaxShuntVolt',	{ formatter: (x) => {return x/100;}})
-		.uint8('DailySessionMinShuntSoc', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8('DailySessionMaxShuntSoc', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8('DailySessionThermalBandA',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandB',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandC',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandD',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandE',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandF',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandG',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandH',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandA',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandB',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandC',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandD',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandE',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandF',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandG',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandH',			{ formatter: (x) => {return x/10;}}) // hours
-		.int16le('DailySessionShuntPeakCharge',{ formatter: (x) => {return x/100;}}) // amps
-		.int16le('DailySessionShuntPeakDischg',{ formatter: (x) => {return x/100;}}) // amps
-		.uint8('DailySessionCriticalEvents')
-		.int32le('DailySessionStartTime') 	// Epoch
-		.int32le('DailySessionFinishTime')  // Epoch
-		.floatle('DailySessionCumulShuntAhCharge',{ formatter: (x) => {return x/1000;}})  // Ah
-		.floatle('DailySessionCumulShuntAhDischg',{ formatter: (x) => {return x/1000;}})  // Ah
-		.floatle('DailySessionCumulShuntkWhCharge',{ formatter: (x) => {return x/1000;}}) // kWh
-		.floatle('DailySessionCumulShuntkWhDischg',{ formatter: (x) => {return x/1000;}}) // kWh
-		
-		return status.parse(msg);
-	}
-}       
+// Category    = Telemetry
+// Object      = Daily Session
+// MsgLength   = 69
+// Description = Daily session today in progress calc
+// Version     = 2
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid from  = SW 1.0.30
+const status = new Parser()
+	.skip(8)
+	.int16le('DailySessionMinCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.int16le('DailySessionMaxCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.int16le('DailySessionMinSupplyVolt',	{ formatter: (x) => {return x/100;}})
+	.int16le('DailySessionMaxSupplyVolt',	{ formatter: (x) => {return x/100;}})
+	.uint8('DailySessionMinReportTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('DailySessionMaxReportTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.int16le('DailySessionMinShuntVolt',	{ formatter: (x) => {return x/100;}})
+	.int16le('DailySessionMaxShuntVolt',	{ formatter: (x) => {return x/100;}})
+	.uint8('DailySessionMinShuntSoc', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8('DailySessionMaxShuntSoc', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8('DailySessionThermalBandA',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandB',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandC',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandD',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandE',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandF',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandG',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandH',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandA',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandB',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandC',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandD',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandE',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandF',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandG',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandH',			{ formatter: (x) => {return x/10;}}) // hours
+	.int16le('DailySessionShuntPeakCharge',{ formatter: (x) => {return x/100;}}) // amps
+	.int16le('DailySessionShuntPeakDischg',{ formatter: (x) => {return x/100;}}) // amps
+	.uint8('DailySessionCriticalEvents')
+	.int32le('DailySessionStartTime') 	// Epoch
+	.int32le('DailySessionFinishTime')  // Epoch
+	.floatle('DailySessionCumulShuntAhCharge',{ formatter: (x) => {return x/1000;}})  // Ah
+	.floatle('DailySessionCumulShuntAhDischg',{ formatter: (x) => {return x/1000;}})  // Ah
+	.floatle('DailySessionCumulShuntkWhCharge',{ formatter: (x) => {return x/1000;}}) // kWh
+	.floatle('DailySessionCumulShuntkWhDischg',{ formatter: (x) => {return x/1000;}}) // kWh
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
+}

--- a/payload/Msg_5457_DailySession.js
+++ b/payload/Msg_5457_DailySession.js
@@ -1,53 +1,50 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Telemetry 
-	// Object      = Daily Session
-	// MsgLength   = 61
-	// Description = Daily session today in progress calc
-	// Version     = 1
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_5457 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.int16le('DailySessionMinCellVolt',		{ formatter: (x) => {return x/1000;}})
-		.int16le('DailySessionMaxCellVolt',		{ formatter: (x) => {return x/1000;}})
-		.int16le('DailySessionMinSupplyVolt',	{ formatter: (x) => {return x/100;}})
-		.int16le('DailySessionMaxSupplyVolt',	{ formatter: (x) => {return x/100;}})
-		.uint8('DailySessionMinReportTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.uint8('DailySessionMaxReportTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
-		.int16le('DailySessionMinShuntVolt',	{ formatter: (x) => {return x/100;}})
-		.int16le('DailySessionMaxShuntVolt',	{ formatter: (x) => {return x/100;}})
-		.uint8('DailySessionMinShuntSoc', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8('DailySessionMaxShuntSoc', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8('DailySessionThermalBandA',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandB',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandC',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandD',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandE',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandF',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandG',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionThermalBandH',		{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandA',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandB',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandC',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandD',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandE',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandF',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandG',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionSocBandH',			{ formatter: (x) => {return x/10;}}) // hours
-		.int16le('DailySessionShuntPeakCharge',{ formatter: (x) => {return x/100;}}) // amps
-		.int16le('DailySessionShuntPeakDischg',{ formatter: (x) => {return x/100;}}) // amps
-		.uint8('DailySessionCriticalEvents')
-		.int32le('DailySessionStartTime') 	// Epoch
-		.int32le('DailySessionFinishTime')  // Epoch
-		.floatle('DailySessionCumulShuntAhCharge',{ formatter: (x) => {return x/1000;}}) // Ah
-		.floatle('DailySessionCumulShuntAhDischg',{ formatter: (x) => {return x/1000;}}) // Ah
-		
-		return status.parse(msg);
-	}
-}       
+// Category    = Telemetry
+// Object      = Daily Session
+// MsgLength   = 61
+// Description = Daily session today in progress calc
+// Version     = 1
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.int16le('DailySessionMinCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.int16le('DailySessionMaxCellVolt',		{ formatter: (x) => {return x/1000;}})
+	.int16le('DailySessionMinSupplyVolt',	{ formatter: (x) => {return x/100;}})
+	.int16le('DailySessionMaxSupplyVolt',	{ formatter: (x) => {return x/100;}})
+	.uint8('DailySessionMinReportTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.uint8('DailySessionMaxReportTemp',		{ formatter: (x) => {return x-40;}}) // temperature ºC
+	.int16le('DailySessionMinShuntVolt',	{ formatter: (x) => {return x/100;}})
+	.int16le('DailySessionMaxShuntVolt',	{ formatter: (x) => {return x/100;}})
+	.uint8('DailySessionMinShuntSoc', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8('DailySessionMaxShuntSoc', 		{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8('DailySessionThermalBandA',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandB',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandC',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandD',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandE',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandF',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandG',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionThermalBandH',		{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandA',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandB',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandC',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandD',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandE',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandF',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandG',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionSocBandH',			{ formatter: (x) => {return x/10;}}) // hours
+	.int16le('DailySessionShuntPeakCharge',{ formatter: (x) => {return x/100;}}) // amps
+	.int16le('DailySessionShuntPeakDischg',{ formatter: (x) => {return x/100;}}) // amps
+	.uint8('DailySessionCriticalEvents')
+	.int32le('DailySessionStartTime') 	// Epoch
+	.int32le('DailySessionFinishTime')  // Epoch
+	.floatle('DailySessionCumulShuntAhCharge',{ formatter: (x) => {return x/1000;}}) // Ah
+	.floatle('DailySessionCumulShuntAhDischg',{ formatter: (x) => {return x/1000;}}) // Ah
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
+}

--- a/payload/Msg_5632_LifetimeMetrics.js
+++ b/payload/Msg_5632_LifetimeMetrics.js
@@ -1,53 +1,50 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
-	
-	// Category    = Telemetry Metrics
-	// Object      = Shunt
-	// MsgLength   = 115
-	// Description = Telemetry Lifetime metrics
-	// Version     = 2
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_5632 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint32le('FirstSyncTime') 			// Epoch
-		.uint32le('LifeCountStartup') 
-		.uint32le('LifeCountCriticalBattOk') 
-		.uint32le('LifeCountChargeOn') 
-		.uint32le('LifeCountChargeLimp') 
-		.uint32le('LifeCountDischgOn') 
-		.uint32le('LifeCountDischgLimp') 
-		.uint32le('LifeCountHeatOn') 
-		.uint32le('LifeCountCoolOn') 
-		.int16le( 'LifeCountDailySession') 
-		.uint32le('RecentTimeCriticalOn') 	// Epoch
-		.uint32le('RecentTimeCriticalOff') 	// Epoch
-		.uint32le('RecentTimeChargeOn') 	// Epoch
-		.uint32le('RecentTimeChargeOff') 	// Epoch
-		.uint32le('RecentTimeChargeLimp') 	// Epoch
-		.uint32le('RecentTimeDischgOn') 	// Epoch
-		.uint32le('RecentTimeDischgOff') 	// Epoch
-		.uint32le('RecentTimeDischgLimp') 	// Epoch
-		.uint32le('RecentTimeHeatOn') 		// Epoch
-		.uint32le('RecentTimeHeatOff') 		// Epoch
-		.uint32le('RecentTimeCoolOn') 		// Epoch
-		.uint32le('RecentTimeCoolOff') 		// Epoch
-		.uint32le('RecentTimeBypassInitial') // Epoch
-		.uint32le('RecentTimeBypassComplete') // Epoch
-		.uint32le('RecentTimeBypassTest') 	// Epoch
-		.uint8('SystemBypassTestOutcome')  /* Choices BypassTestOutcomes
-			NotTested = 0,
-			Preparing = 1,
-			Testing = 2,
-			PassOk = 3,
-			Failed = 4, */
-		.uint32le('RecentTimeWizardSetup') // Epoch
-		.uint32le('RecentTimeBypassExtra') // Epoch
+﻿const Parser = require('binary-parser').Parser;
 
-		return status.parse(msg);
-	}
+// Category    = Telemetry Metrics
+// Object      = Shunt
+// MsgLength   = 115
+// Description = Telemetry Lifetime metrics
+// Version     = 2
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint32le('FirstSyncTime') 			// Epoch
+	.uint32le('LifeCountStartup')
+	.uint32le('LifeCountCriticalBattOk')
+	.uint32le('LifeCountChargeOn')
+	.uint32le('LifeCountChargeLimp')
+	.uint32le('LifeCountDischgOn')
+	.uint32le('LifeCountDischgLimp')
+	.uint32le('LifeCountHeatOn')
+	.uint32le('LifeCountCoolOn')
+	.int16le( 'LifeCountDailySession')
+	.uint32le('RecentTimeCriticalOn') 	// Epoch
+	.uint32le('RecentTimeCriticalOff') 	// Epoch
+	.uint32le('RecentTimeChargeOn') 	// Epoch
+	.uint32le('RecentTimeChargeOff') 	// Epoch
+	.uint32le('RecentTimeChargeLimp') 	// Epoch
+	.uint32le('RecentTimeDischgOn') 	// Epoch
+	.uint32le('RecentTimeDischgOff') 	// Epoch
+	.uint32le('RecentTimeDischgLimp') 	// Epoch
+	.uint32le('RecentTimeHeatOn') 		// Epoch
+	.uint32le('RecentTimeHeatOff') 		// Epoch
+	.uint32le('RecentTimeCoolOn') 		// Epoch
+	.uint32le('RecentTimeCoolOff') 		// Epoch
+	.uint32le('RecentTimeBypassInitial') // Epoch
+	.uint32le('RecentTimeBypassComplete') // Epoch
+	.uint32le('RecentTimeBypassTest') 	// Epoch
+	.uint8('SystemBypassTestOutcome')  /* Choices BypassTestOutcomes
+		NotTested = 0,
+		Preparing = 1,
+		Testing = 2,
+		PassOk = 3,
+		Failed = 4, */
+	.uint32le('RecentTimeWizardSetup') // Epoch
+	.uint32le('RecentTimeBypassExtra') // Epoch
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_5732_SystemDiscovery.js
+++ b/payload/Msg_5732_SystemDiscovery.js
@@ -1,81 +1,78 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Discovery
-	// MsgLength   = 50
-	// Description = System Discovery message
-	// Version     = 2
-	// Frequency   = 2 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_5732 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.string('SystemCode', 	{ encoding: 'ascii', length: 8, stripNull: true })
-		.int16le('SystemFirmwareVersion')
-		.int16le('SystemHardwareVersion')
-		.int32le('SystemTime') // Epoch
-		.uint8('SystemOpStatus') /* Choices
-				Simulator = 0,   	  // LED = rainbow pulse
-				Idle = 1,        	  // LED = green slow pulse
-				Discharging = 2, 	  // LED = green solid 
-				SoC Empty = 3,   	  // LED = green double blink
-				Charging = 4,    	  // LED = blue slow pulse
-				Full = 5,        	  // LED = blue double blink
-				Timeout = 6,     	  // LED = red solid
-				Critical Pending = 7, // LED = red fast pulse
-				Critical Offline = 8, // LED = red slow pulse
-				Mqtt Offline = 9,     // LED = white blink
-				Auth Setup = 10,      // LED = white solid
-				Shunt Timeout = 11,   // LED = red solid  	*/
-		.uint8('SystemAuthMode') /* Choices
-				Default 	= 0,
-				Technician 	= 1,
-				Factory 	= 2, */
-		.uint8('CriticalBatOkState')    // 0 = Off , 1 = On
-		.uint8('ChargePowerRateState')  /* Choices
-				Off 			= 0,
-				Limited Power 	= 2,
-				Normal Power  	= 4, */
-		.uint8('DischargePowerRateState') /* Choices
-				Off 			= 0,
-				Limited Power 	= 2,
-				Normal Power  	= 4, */
-		.uint8('HeatOnState') 			// 0 = Off , 1 = On
-		.uint8('CoolOnState') 			// 0 = Off , 1 = On
-		.int16le('MinCellVolt', 	{ formatter: (x) => {return x/1000;}})
-		.int16le('MaxCellVolt', 	{ formatter: (x) => {return x/1000;}})
-		.int16le('AvgCellVolt', 	{ formatter: (x) => {return x/1000;}})
-		.uint8('MinCellTemp', 		{ formatter: (x) => {return x-40;}})     // temperature ºC
-		.uint8('NumOfCellsActive')
-		.uint8('CmuRxOpStatusUSN')
-		.uint8('CmuPollerMode')  /* Choices
-				Idle = 0,
-				Normal = 1,
-				Collection Start = 2,
-				Collection Running = 3,
-				Sync Start = 4,
-				Sync Running = 5,
-				NetworkTest Start = 6,
-				NetworkTest Running = 9,
-				BypassTest Start = 7,
-				BypassTest Running = 8,
-				RebootAll Start = 10,
-				Rebooting AllDevices = 11,
-				Simulator Start = 12,
-				Simulator Running = 13, */
-		.uint8('ShuntSOC',			{ formatter: (x) => {return x/2-5;}})    // percent
-		.int16le('ShuntVoltage',	{ formatter: (x) => {return x/100;}})
-		.floatle('ShuntCurrent',	{ formatter: (x) => {return x/1000;}})
-		.uint8('ShuntStatus') /* Choices
-				Timeout = 0,
-				Discharging = 1,
-				Idle = 2,
-				Charging = 4 */
-		.uint8('ShuntRxAmpTicks')
+// Category    = Discovery
+// MsgLength   = 50
+// Description = System Discovery message
+// Version     = 2
+// Frequency   = 2 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.string('SystemCode', 	{ encoding: 'ascii', length: 8, stripNull: true })
+	.int16le('SystemFirmwareVersion')
+	.int16le('SystemHardwareVersion')
+	.int32le('SystemTime') // Epoch
+	.uint8('SystemOpStatus') /* Choices
+			Simulator = 0,   	  // LED = rainbow pulse
+			Idle = 1,        	  // LED = green slow pulse
+			Discharging = 2, 	  // LED = green solid
+			SoC Empty = 3,   	  // LED = green double blink
+			Charging = 4,    	  // LED = blue slow pulse
+			Full = 5,        	  // LED = blue double blink
+			Timeout = 6,     	  // LED = red solid
+			Critical Pending = 7, // LED = red fast pulse
+			Critical Offline = 8, // LED = red slow pulse
+			Mqtt Offline = 9,     // LED = white blink
+			Auth Setup = 10,      // LED = white solid
+			Shunt Timeout = 11,   // LED = red solid  	*/
+	.uint8('SystemAuthMode') /* Choices
+			Default 	= 0,
+			Technician 	= 1,
+			Factory 	= 2, */
+	.uint8('CriticalBatOkState')    // 0 = Off , 1 = On
+	.uint8('ChargePowerRateState')  /* Choices
+			Off 			= 0,
+			Limited Power 	= 2,
+			Normal Power  	= 4, */
+	.uint8('DischargePowerRateState') /* Choices
+			Off 			= 0,
+			Limited Power 	= 2,
+			Normal Power  	= 4, */
+	.uint8('HeatOnState') 			// 0 = Off , 1 = On
+	.uint8('CoolOnState') 			// 0 = Off , 1 = On
+	.int16le('MinCellVolt', 	{ formatter: (x) => {return x/1000;}})
+	.int16le('MaxCellVolt', 	{ formatter: (x) => {return x/1000;}})
+	.int16le('AvgCellVolt', 	{ formatter: (x) => {return x/1000;}})
+	.uint8('MinCellTemp', 		{ formatter: (x) => {return x-40;}})     // temperature ºC
+	.uint8('NumOfCellsActive')
+	.uint8('CmuRxOpStatusUSN')
+	.uint8('CmuPollerMode')  /* Choices
+			Idle = 0,
+			Normal = 1,
+			Collection Start = 2,
+			Collection Running = 3,
+			Sync Start = 4,
+			Sync Running = 5,
+			NetworkTest Start = 6,
+			NetworkTest Running = 9,
+			BypassTest Start = 7,
+			BypassTest Running = 8,
+			RebootAll Start = 10,
+			Rebooting AllDevices = 11,
+			Simulator Start = 12,
+			Simulator Running = 13, */
+	.uint8('ShuntSOC',			{ formatter: (x) => {return x/2-5;}})    // percent
+	.int16le('ShuntVoltage',	{ formatter: (x) => {return x/100;}})
+	.floatle('ShuntCurrent',	{ formatter: (x) => {return x/1000;}})
+	.uint8('ShuntStatus') /* Choices
+			Timeout = 0,
+			Discharging = 1,
+			Idle = 2,
+			Charging = 4 */
+	.uint8('ShuntRxAmpTicks')
 
-		return status.parse(msg);
-	}
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_5831_DailySessionHist.js
+++ b/payload/Msg_5831_DailySessionHist.js
@@ -1,54 +1,51 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Session history
-	// Object      = Quick
-	// MsgLength   = 60
-	// Description = Daily session history
-	// Version     = 1
-	// Frequency   = adhoc
-	// Support     = Current
-	// Created     = SW 1.0.29
-	this.parse_5831 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.int16le('DailySessionHistId')
-		.uint32le('DailySessionHistTime') 		// Epoch   *** log key ***
-		.uint8('DailySessionHistCriticalEvents')
-		.skip(1)
-		.uint8('DailySessionHistMinReportTemp',			{ formatter: (x) => {return x-40;}})	// temperature ºC
-		.uint8('DailySessionHistMaxReportTemp',			{ formatter: (x) => {return x-40;}})	// temperature ºC
-		.uint8('DailySessionHistMinShuntSoc', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.uint8('DailySessionHistMaxShuntSoc', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
-		.int16le('DailySessionHistMinCellVolt',			{ formatter: (x) => {return x/1000;}})
-		.int16le('DailySessionHistMaxCellVolt',			{ formatter: (x) => {return x/1000;}})
-		.int16le('DailySessionHistMinSupplyVolt',		{ formatter: (x) => {return x/100;}})
-		.int16le('DailySessionHistMaxSupplyVolt',		{ formatter: (x) => {return x/100;}})
-		.int16le('DailySessionHistMinShuntVolt',		{ formatter: (x) => {return x/100;}})
-		.int16le('DailySessionHistMaxShuntVolt',		{ formatter: (x) => {return x/100;}})
-		.uint8('DailySessionHistThermalBandA',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistThermalBandB',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistThermalBandC',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistThermalBandD',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistThermalBandE',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistThermalBandF',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistThermalBandG',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistThermalBandH',			{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistSocBandA',				{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistSocBandB',				{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistSocBandC',				{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistSocBandD',				{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistSocBandE',				{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistSocBandF',				{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistSocBandG',				{ formatter: (x) => {return x/10;}}) // hours
-		.uint8('DailySessionHistSocBandH',				{ formatter: (x) => {return x/10;}}) // hours
-		.int16le('DailySessionHistShuntPeakCharge',		{ formatter: (x) => {return x/100;}})  // amp
-		.int16le('DailySessionHistShuntPeakDischg',		{ formatter: (x) => {return x/100;}})  // amp
-		.int16le('DailySessionHistCumulShuntAhCharge',	{ formatter: (x) => {return x/1000;}}) // Ah
-		.int16le('DailySessionHistCumulShuntAhDischg',	{ formatter: (x) => {return x/1000;}}) // Ah
-		
-		return status.parse(msg);
-	}
+// Category    = Session history
+// Object      = Quick
+// MsgLength   = 60
+// Description = Daily session history
+// Version     = 1
+// Frequency   = adhoc
+// Support     = Current
+// Created     = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.int16le('DailySessionHistId')
+	.uint32le('DailySessionHistTime') 		// Epoch   *** log key ***
+	.uint8('DailySessionHistCriticalEvents')
+	.skip(1)
+	.uint8('DailySessionHistMinReportTemp',			{ formatter: (x) => {return x-40;}})	// temperature ºC
+	.uint8('DailySessionHistMaxReportTemp',			{ formatter: (x) => {return x-40;}})	// temperature ºC
+	.uint8('DailySessionHistMinShuntSoc', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.uint8('DailySessionHistMaxShuntSoc', 			{ formatter: (x) => {return (x-5)/2;}}) // percent
+	.int16le('DailySessionHistMinCellVolt',			{ formatter: (x) => {return x/1000;}})
+	.int16le('DailySessionHistMaxCellVolt',			{ formatter: (x) => {return x/1000;}})
+	.int16le('DailySessionHistMinSupplyVolt',		{ formatter: (x) => {return x/100;}})
+	.int16le('DailySessionHistMaxSupplyVolt',		{ formatter: (x) => {return x/100;}})
+	.int16le('DailySessionHistMinShuntVolt',		{ formatter: (x) => {return x/100;}})
+	.int16le('DailySessionHistMaxShuntVolt',		{ formatter: (x) => {return x/100;}})
+	.uint8('DailySessionHistThermalBandA',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistThermalBandB',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistThermalBandC',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistThermalBandD',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistThermalBandE',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistThermalBandF',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistThermalBandG',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistThermalBandH',			{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistSocBandA',				{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistSocBandB',				{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistSocBandC',				{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistSocBandD',				{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistSocBandE',				{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistSocBandF',				{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistSocBandG',				{ formatter: (x) => {return x/10;}}) // hours
+	.uint8('DailySessionHistSocBandH',				{ formatter: (x) => {return x/10;}}) // hours
+	.int16le('DailySessionHistShuntPeakCharge',		{ formatter: (x) => {return x/100;}})  // amp
+	.int16le('DailySessionHistShuntPeakDischg',		{ formatter: (x) => {return x/100;}})  // amp
+	.int16le('DailySessionHistCumulShuntAhCharge',	{ formatter: (x) => {return x/1000;}}) // Ah
+	.int16le('DailySessionHistCumulShuntAhDischg',	{ formatter: (x) => {return x/1000;}}) // Ah
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_6131_StatusComms.js
+++ b/payload/Msg_6131_StatusComms.js
@@ -1,101 +1,98 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Aggregated telemetry
-	// Object      = Communication
-	// MsgLength   = 33
-	// Description = Combined status Communication
-	// Version     = 1
-	// Frequency   = 2 seconds
-	// Support     = Current
-	// Created     = SW 1.0.29
-	this.parse_6131 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint32le('SystemTime') // Epoch
-		.uint8('SystemOpStatus') /* Choices
-				Simulator = 0,   	  // LED = rainbow pulse
-				Idle = 1,        	  // LED = green slow pulse
-				Discharging = 2, 	  // LED = green solid 
-				SoC Empty = 3,   	  // LED = green double blink
-				Charging = 4,    	  // LED = blue slow pulse
-				Full = 5,        	  // LED = blue double blink
-				Timeout = 6,     	  // LED = red solid
-				Critical Pending = 7, // LED = red fast pulse
-				Critical Offline = 8, // LED = red slow pulse
-				Mqtt Offline = 9,     // LED = white blink
-				Auth Setup = 10,      // LED = white solid
-				Shunt Timeout = 11,   // LED = red solid  	*/
-		.uint8('SystemAuthMode') /* Choices
-				Default = 0,
-				Technician = 1,
-				Factory = 2, */
-		.int16le('SystemAuthToken')
-		.int16le('SystemAuthRejectTicks')
-		.uint8('WifiState') /* Choices WifiOpStates
-				Broadcast Start = 0,
-				Broadcast Prep = 1,
-				Broadcast TxSetup = 2,
-				Broadcast Running = 3,
-				UsbCmd Start = 4,
-				UsbCmd Running = 5,
-				UsbCmd PassThru = 6,
-				UsbProg Start = 7,
-				UsbProg Running = 8,
-				UsbProg PassThru = 9,
-				Offline Start = 10,
-				Offline Running = 11,
-				Offline Stop = 12,
-				Limited Start = 13,
-				Limited Prep = 14,
-				Limited Running = 15,
-				JoinAp Start = 16,
-				JoinAp Running = 17,	*/		
-		.uint8('WifiTxCmdTicks') 
-		.uint8('WifiRxCmdTicks') 
-		.uint8('WifiRxUnknownTicks') 
-		.uint8('CanbusOpStatus') /* Choices 
-				
-				 	*/		
-		.uint8('CanbusRxStatusTicks')
-		.uint8('CanbusRxUnknownTicks')
-		.uint8('CanbusRxStatusTicks')
-		.uint8('ShuntPollerMode') /* Choices ShuntPollerModes
-				Idle Start = 0,
-				Idle = 1,
-				Sync Start = 2,
-				Sync Running = 3,
-				Normal = 4,
-				ShuntMon2 SetupStart = 5,
-				ShuntMon2 SetupRunning = 6,
-				ShuntMon2 Normal = 7, */
-		.uint8('ShuntStatus') /* Choices  ShuntStatuses
-				Timeout = 0,
-				Discharging = 1,
-				Idle = 2,
-				Charging = 4 */
-		.uint8('ShuntRxAmpTicks')
-		.uint8('ShuntTxAmpTicks')
-		.uint8('CmuPollerMode') 	    /* Choices
-				Idle = 0,
-				Normal = 1,
-				Collection Start = 2,
-				Collection Running = 3,
-				Sync Start = 4,
-				Sync Running = 5,
-				NetworkTest Start = 6,
-				NetworkTest Running = 9,
-				BypassTest Start = 7,
-				BypassTest Running = 8,
-				RebootAll Start = 10,
-				Rebooting AllDevices = 11,
-				Simulator Start = 12,
-				Simulator Running = 13, */
-		.uint8('CmuOpStatus') /* Choices */
-		.uint8('CmuTxCmdTicks')
-		
-		return status.parse(msg);
-	}
+// Category    = Aggregated telemetry
+// Object      = Communication
+// MsgLength   = 33
+// Description = Combined status Communication
+// Version     = 1
+// Frequency   = 2 seconds
+// Support     = Current
+// Created     = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint32le('SystemTime') // Epoch
+	.uint8('SystemOpStatus') /* Choices
+			Simulator = 0,   	  // LED = rainbow pulse
+			Idle = 1,        	  // LED = green slow pulse
+			Discharging = 2, 	  // LED = green solid
+			SoC Empty = 3,   	  // LED = green double blink
+			Charging = 4,    	  // LED = blue slow pulse
+			Full = 5,        	  // LED = blue double blink
+			Timeout = 6,     	  // LED = red solid
+			Critical Pending = 7, // LED = red fast pulse
+			Critical Offline = 8, // LED = red slow pulse
+			Mqtt Offline = 9,     // LED = white blink
+			Auth Setup = 10,      // LED = white solid
+			Shunt Timeout = 11,   // LED = red solid  	*/
+	.uint8('SystemAuthMode') /* Choices
+			Default = 0,
+			Technician = 1,
+			Factory = 2, */
+	.int16le('SystemAuthToken')
+	.int16le('SystemAuthRejectTicks')
+	.uint8('WifiState') /* Choices WifiOpStates
+			Broadcast Start = 0,
+			Broadcast Prep = 1,
+			Broadcast TxSetup = 2,
+			Broadcast Running = 3,
+			UsbCmd Start = 4,
+			UsbCmd Running = 5,
+			UsbCmd PassThru = 6,
+			UsbProg Start = 7,
+			UsbProg Running = 8,
+			UsbProg PassThru = 9,
+			Offline Start = 10,
+			Offline Running = 11,
+			Offline Stop = 12,
+			Limited Start = 13,
+			Limited Prep = 14,
+			Limited Running = 15,
+			JoinAp Start = 16,
+			JoinAp Running = 17,	*/
+	.uint8('WifiTxCmdTicks')
+	.uint8('WifiRxCmdTicks')
+	.uint8('WifiRxUnknownTicks')
+	.uint8('CanbusOpStatus') /* Choices
+
+				*/
+	.uint8('CanbusRxStatusTicks')
+	.uint8('CanbusRxUnknownTicks')
+	.uint8('CanbusRxStatusTicks')
+	.uint8('ShuntPollerMode') /* Choices ShuntPollerModes
+			Idle Start = 0,
+			Idle = 1,
+			Sync Start = 2,
+			Sync Running = 3,
+			Normal = 4,
+			ShuntMon2 SetupStart = 5,
+			ShuntMon2 SetupRunning = 6,
+			ShuntMon2 Normal = 7, */
+	.uint8('ShuntStatus') /* Choices  ShuntStatuses
+			Timeout = 0,
+			Discharging = 1,
+			Idle = 2,
+			Charging = 4 */
+	.uint8('ShuntRxAmpTicks')
+	.uint8('ShuntTxAmpTicks')
+	.uint8('CmuPollerMode') 	    /* Choices
+			Idle = 0,
+			Normal = 1,
+			Collection Start = 2,
+			Collection Running = 3,
+			Sync Start = 4,
+			Sync Running = 5,
+			NetworkTest Start = 6,
+			NetworkTest Running = 9,
+			BypassTest Start = 7,
+			BypassTest Running = 8,
+			RebootAll Start = 10,
+			Rebooting AllDevices = 11,
+			Simulator Start = 12,
+			Simulator Running = 13, */
+	.uint8('CmuOpStatus') /* Choices */
+	.uint8('CmuTxCmdTicks')
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_6831_QuickSessionHist.js
+++ b/payload/Msg_6831_QuickSessionHist.js
@@ -1,44 +1,41 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Session history
-	// Object      = Quick
-	// MsgLength   = 32
-	// Description = Quick session history
-	// Version     = 1
-	// Frequency   = adhoc
-	// Support     = Current
-	// Created     = SW 1.0.29
-	this.parse_6831 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.int16le('QuickSessionHistId')
-		.uint32le('QuickSessionHistTime') 		// Epoch  *** log key ***
-		.uint8('QuickSessionHistSystemOpState') /* Choices
-				Simulator = 0,   	  // LED = rainbow pulse
-				Idle = 1,        	  // LED = green slow pulse
-				Discharging = 2, 	  // LED = green solid 
-				SoC Empty = 3,   	  // LED = green double blink
-				Charging = 4,    	  // LED = blue slow pulse
-				Full = 5,        	  // LED = blue double blink
-				Timeout = 6,     	  // LED = red solid
-				Critical Pending = 7, // LED = red fast pulse
-				Critical Offline = 8, // LED = red slow pulse
-				Mqtt Offline = 9,     // LED = white blink
-				Auth Setup = 10,      // LED = white solid
-				Shunt Timeout = 11,   // LED = red solid  	*/
-		.uint8( 'QuickSessionHistControlLogic')  
-		.int16le('QuickSessionHistMinCellVolt',			{ formatter: (x) => {return x/1000;}})
-		.int16le('QuickSessionHistMaxCellVolt',			{ formatter: (x) => {return x/1000;}})
-		.int16le('QuickSessionHistAvgCellVolt',			{ formatter: (x) => {return x/1000;}})
-		.uint8(  'QuickSessionHistAvgCellTemp',			{ formatter: (x) => {return x-40;}})	// temperature ºC
-		.int16le('QuickSessionHistSocHiRes',			{ formatter: (x) => {return x/100;}})	// percent
-		.int16le('QuickSessionHistShuntVolt',			{ formatter: (x) => {return x/100;}})
-		.floatle('QuickSessionHistShuntAmp',			{ formatter: (x) => {return x/1000;}})  // amp
-		.uint8(  'QuickSessionHistNumOfCellsInBypass')
+// Category    = Session history
+// Object      = Quick
+// MsgLength   = 32
+// Description = Quick session history
+// Version     = 1
+// Frequency   = adhoc
+// Support     = Current
+// Created     = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.int16le('QuickSessionHistId')
+	.uint32le('QuickSessionHistTime') 		// Epoch  *** log key ***
+	.uint8('QuickSessionHistSystemOpState') /* Choices
+			Simulator = 0,   	  // LED = rainbow pulse
+			Idle = 1,        	  // LED = green slow pulse
+			Discharging = 2, 	  // LED = green solid
+			SoC Empty = 3,   	  // LED = green double blink
+			Charging = 4,    	  // LED = blue slow pulse
+			Full = 5,        	  // LED = blue double blink
+			Timeout = 6,     	  // LED = red solid
+			Critical Pending = 7, // LED = red fast pulse
+			Critical Offline = 8, // LED = red slow pulse
+			Mqtt Offline = 9,     // LED = white blink
+			Auth Setup = 10,      // LED = white solid
+			Shunt Timeout = 11,   // LED = red solid  	*/
+	.uint8( 'QuickSessionHistControlLogic')
+	.int16le('QuickSessionHistMinCellVolt',			{ formatter: (x) => {return x/1000;}})
+	.int16le('QuickSessionHistMaxCellVolt',			{ formatter: (x) => {return x/1000;}})
+	.int16le('QuickSessionHistAvgCellVolt',			{ formatter: (x) => {return x/1000;}})
+	.uint8(  'QuickSessionHistAvgCellTemp',			{ formatter: (x) => {return x-40;}})	// temperature ºC
+	.int16le('QuickSessionHistSocHiRes',			{ formatter: (x) => {return x/100;}})	// percent
+	.int16le('QuickSessionHistShuntVolt',			{ formatter: (x) => {return x/100;}})
+	.floatle('QuickSessionHistShuntAmp',			{ formatter: (x) => {return x/1000;}})  // amp
+	.uint8(  'QuickSessionHistNumOfCellsInBypass')
 
-		return status.parse(msg);
-	}
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }

--- a/payload/Msg_7857_HwShuntMetrics.js
+++ b/payload/Msg_7857_HwShuntMetrics.js
@@ -1,39 +1,36 @@
-﻿module.exports = function() 
-{ 
-	var Parser = require('binary-parser').Parser;
+﻿const Parser = require('binary-parser').Parser;
 
-	// Category    = Telemetry Metrics
-	// Object      = Shunt
-	// MsgLength   = 76
-	// Description = Hardware shunt metrics
-	// Version     = 1
-	// Frequency   = 20 seconds
-	// Support     = Current
-	// Valid to    = SW 1.0.29
-	this.parse_7857 = function(msg) 
-	{
-		var status = new Parser()
-		.skip(8)
-		.uint8('ShuntSocCycles')  
-		.uint32le('RecentTimeAcculmSave') 	// Epoch
-		.uint32le('RecentTimeSocLoRecal') 	// Epoch
-		.uint32le('RecentTimeSocHiRecal') 	// Epoch
-		.uint32le('RecentTimeSocCountLo') 	// Epoch
-		.uint32le('RecentTimeSocCountHi') 	// Epoch
-		.uint8(  'hasShuntSocCountLo') 		// boolean 0 = Off , 1 = On
-		.uint8(  'hasShuntSocCountHi') 		// boolean 0 = Off , 1 = On
-		.int16le('EstDurationToFullmins') 
-		.int16le('EstDurationToEmptymins') 
-		.floatle('ShuntAcculmAvgCharge',	{ formatter: (x) => {return x/1000;}})	// Ah
-		.floatle('ShuntAcculmAvgDischg',	{ formatter: (x) => {return x/1000;}})	// Ah
-		.floatle('ShuntAcculmAvgNett',		{ formatter: (x) => {return x/1000;}})	// Ah
-		.uint32le('ShuntSerialNo') 
-		.uint32le('ShuntManuCode') 
-		.int16le('ShuntPartNum')
-		.int16le('ShuntVersCode')
-		.string('ShuntPns1', 				{ encoding: 'ascii', length: 8 })
-		.string('ShuntPns2', 				{ encoding: 'ascii', length: 8 })
-						
-		return status.parse(msg);
-	}
+// Category    = Telemetry Metrics
+// Object      = Shunt
+// MsgLength   = 76
+// Description = Hardware shunt metrics
+// Version     = 1
+// Frequency   = 20 seconds
+// Support     = Current
+// Valid to    = SW 1.0.29
+const status = new Parser()
+	.skip(8)
+	.uint8('ShuntSocCycles')
+	.uint32le('RecentTimeAcculmSave') 	// Epoch
+	.uint32le('RecentTimeSocLoRecal') 	// Epoch
+	.uint32le('RecentTimeSocHiRecal') 	// Epoch
+	.uint32le('RecentTimeSocCountLo') 	// Epoch
+	.uint32le('RecentTimeSocCountHi') 	// Epoch
+	.uint8(  'hasShuntSocCountLo') 		// boolean 0 = Off , 1 = On
+	.uint8(  'hasShuntSocCountHi') 		// boolean 0 = Off , 1 = On
+	.int16le('EstDurationToFullmins')
+	.int16le('EstDurationToEmptymins')
+	.floatle('ShuntAcculmAvgCharge',	{ formatter: (x) => {return x/1000;}})	// Ah
+	.floatle('ShuntAcculmAvgDischg',	{ formatter: (x) => {return x/1000;}})	// Ah
+	.floatle('ShuntAcculmAvgNett',		{ formatter: (x) => {return x/1000;}})	// Ah
+	.uint32le('ShuntSerialNo')
+	.uint32le('ShuntManuCode')
+	.int16le('ShuntPartNum')
+	.int16le('ShuntVersCode')
+	.string('ShuntPns1', 				{ encoding: 'ascii', length: 8 })
+	.string('ShuntPns2', 				{ encoding: 'ascii', length: 8 })
+
+module.exports = function(msg)
+{
+	return status.parse(msg);
 }


### PR DESCRIPTION
Also, Use function reference instead of eval.

On my singleboard Olimex Lime2 this reduces the CPU load of WatchMonUdpListener from 80-100%, to less than 10%.