### PR TITLE
Fix trailing spaces in binary-parser field names causing load errors

### DIFF
--- a/payload/Msg_4732_HwSystemSetup.js
+++ b/payload/Msg_4732_HwSystemSetup.js
@@ -36,58 +36,58 @@ const Parser = require('binary-parser').Parser;
                                 Limited Power   = 2,
                                 Normal Power    = 4, */
       .uint8('isChargePowerRateCalc')                 /* Choices ChargeRateStates */
-      .uint8('hasChargeCellVoltHi ')                          // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeCellVoltPause ')               // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeCellVoltLimPower ')    // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeCellTempLo ')                          // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeCellTempHi ')                          // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeAmbientTempLo ')               // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeAmbientTempHi ')               // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeSupplyVoltHi ')                // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeSupplyVoltPause ')     // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeShuntVoltHi ')                 // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeShuntVoltPause ')              // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeShuntVoltLimPower ')   // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeShuntSocHi ')                          // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeShuntSocPause ')               // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeAboveInitalBypass ')   // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeAboveFinalBypass ')            // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeInBypass ')                    // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeBypassComplete ')              // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeBypassTempRelief ')    // Boolean 0 = Off , 1 = On
-      .uint8('isDischgOnState ')                              // Boolean 0 = Off , 1 = On
-      .uint8('isDischgLimPower ')                     // Boolean 0 = Off , 1 = On
-      .uint8('isDischgTransition ')                   // Boolean 0 = Off , 1 = On
-      .uint8('isDischgPowerRateState ') /* Choices DischgRateStates
+      .uint8('hasChargeCellVoltHi')                          // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeCellVoltPause')               // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeCellVoltLimPower')    // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeCellTempLo')                          // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeCellTempHi')                          // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeAmbientTempLo')               // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeAmbientTempHi')               // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeSupplyVoltHi')                // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeSupplyVoltPause')     // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeShuntVoltHi')                 // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeShuntVoltPause')              // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeShuntVoltLimPower')   // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeShuntSocHi')                          // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeShuntSocPause')               // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeAboveInitalBypass')   // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeAboveFinalBypass')            // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeInBypass')                    // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeBypassComplete')              // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeBypassTempRelief')    // Boolean 0 = Off , 1 = On
+      .uint8('isDischgOnState')                              // Boolean 0 = Off , 1 = On
+      .uint8('isDischgLimPower')                     // Boolean 0 = Off , 1 = On
+      .uint8('isDischgTransition')                   // Boolean 0 = Off , 1 = On
+      .uint8('isDischgPowerRateState') /* Choices DischgRateStates
                                 Off                     = 0,
                                 Limited Power   = 2,
                                 Normal Power    = 4, */
-      .uint8('isDischgPowerRateCalc ')                /* Choices DischgRateStates */
-      .uint8('hasDischgCellVoltLo ')                          // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgCellVoltPause ')               // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgCellVoltLimPower ')    // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgCellTempLo ')                          // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgCellTempHi ')                          // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgAmbientLo ')                   // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgAmbientHi ')                   // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgSupplyVoltLo ')                // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgSupplyVoltPause ')     // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgShuntVoltLo ')                 // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgShuntVoltPause ')              // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgShuntVoltLimPower ')   // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgShuntSocLo ')                          // Boolean 0 = Off , 1 = On
-      .uint8('hasDischgShuntSocPause ')               // Boolean 0 = Off , 1 = On
-      .uint8('isHeatOnState ')                                // Boolean 0 = Off , 1 = On
-      .uint8('isHeatOnCalc ')                                 // Boolean 0 = Off , 1 = On
-      .uint8('isHeatTransition ')                     // Boolean 0 = Off , 1 = On
-      .uint8('hasHeatAmbientLo ')                     // Boolean 0 = Off , 1 = On
-      .uint8('hasHeatCellTempLo ')                    // Boolean 0 = Off , 1 = On
+      .uint8('isDischgPowerRateCalc')                /* Choices DischgRateStates */
+      .uint8('hasDischgCellVoltLo')                          // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgCellVoltPause')               // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgCellVoltLimPower')    // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgCellTempLo')                          // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgCellTempHi')                          // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgAmbientLo')                   // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgAmbientHi')                   // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgSupplyVoltLo')                // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgSupplyVoltPause')     // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgShuntVoltLo')                 // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgShuntVoltPause')              // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgShuntVoltLimPower')   // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgShuntSocLo')                          // Boolean 0 = Off , 1 = On
+      .uint8('hasDischgShuntSocPause')               // Boolean 0 = Off , 1 = On
+      .uint8('isHeatOnState')                                // Boolean 0 = Off , 1 = On
+      .uint8('isHeatOnCalc')                                 // Boolean 0 = Off , 1 = On
+      .uint8('isHeatTransition')                     // Boolean 0 = Off , 1 = On
+      .uint8('hasHeatAmbientLo')                     // Boolean 0 = Off , 1 = On
+      .uint8('hasHeatCellTempLo')                    // Boolean 0 = Off , 1 = On
       .uint8('isCoolOnState')                                 // Boolean 0 = Off , 1 = On
       .uint8('isCoolOnCalc')                                          // Boolean 0 = Off , 1 = On
       .uint8('isCoolTransition')                              // Boolean 0 = Off , 1 = On
-      .uint8('hasCoolAmbientHi ')                     // Boolean 0 = Off , 1 = On
-      .uint8('hasCoolCellTempHi ')                    // Boolean 0 = Off , 1 = On
-      .uint8('hasChargeBypassSessionLo ')    // Boolean 0 = Off , 1 = On
+      .uint8('hasCoolAmbientHi')                     // Boolean 0 = Off , 1 = On
+      .uint8('hasCoolCellTempHi')                    // Boolean 0 = Off , 1 = On
+      .uint8('hasChargeBypassSessionLo')    // Boolean 0 = Off , 1 = On
 
 module.exports = function(msg)
 {

--- a/payload/Msg_4733_StatusControlLogic.js
+++ b/payload/Msg_4733_StatusControlLogic.js
@@ -42,8 +42,8 @@ const status = new Parser()
     .bit1('isCoolOnState')              // boolean index 15 - bit0
     .bit1('isCoolOnCalc')               // boolean index 15 - bit1
     .bit1('isCoolTransition')           // boolean index 15 - bit2
-    .bit1('hasCoolAmbientHi ')          // boolean index 15 - bit3
-    .bit1('hasCoolCellTempHi ')         // boolean index 15 - bit4
+    .bit1('hasCoolAmbientHi')          // boolean index 15 - bit3
+    .bit1('hasCoolCellTempHi')         // boolean index 15 - bit4
     .bit1('hasAmbientTriggeredHeat')    // boolean index 15 - bit5
     .bit1('hasCellTempTriggeredHeat')   // boolean index 15 - bit6
     .bit1('reserved4')                  // boolean index 15 - bit7
@@ -68,19 +68,19 @@ const status = new Parser()
     .bit1('hasChargeShuntVoltPause')    // boolean index 19 - bit5
     .bit1('hasChargeShuntVoltLimPower') // boolean index 19 - bit6
     .bit1('hasFluidFlowActive')         // boolean index 19 - bit7
-    .bit1('hasChargeShuntSocHi ')       // boolean index 20 - bit0
-    .bit1('hasChargeShuntSocPause ')    // boolean index 20 - bit1
-    .bit1('hasChargeAboveInitalBypass ')// boolean index 20 - bit2
-    .bit1('hasChargeAboveFinalBypass ') // boolean index 20 - bit3
-    .bit1('hasChargeInBypass ')         // boolean index 20 - bit4
-    .bit1('hasChargeBypassComplete ')   // boolean index 20 - bit5
-    .bit1('hasChargeBypassTempRelief ') // boolean index 20 - bit6
-    .bit1('hasChargeBypassSessionLo ')  // boolean index 20 - bit7
+    .bit1('hasChargeShuntSocHi')       // boolean index 20 - bit0
+    .bit1('hasChargeShuntSocPause')    // boolean index 20 - bit1
+    .bit1('hasChargeAboveInitalBypass')// boolean index 20 - bit2
+    .bit1('hasChargeAboveFinalBypass') // boolean index 20 - bit3
+    .bit1('hasChargeInBypass')         // boolean index 20 - bit4
+    .bit1('hasChargeBypassComplete')   // boolean index 20 - bit5
+    .bit1('hasChargeBypassTempRelief') // boolean index 20 - bit6
+    .bit1('hasChargeBypassSessionLo')  // boolean index 20 - bit7
     .uint8('isChargePowerRateAlt')      /* Choices ChargeRateStates */
     .bit1('RebalanceBypassExtra')       // boolean index 22 - bit0
     .bit7('reserved5')
     .skip(1)    
-    .uint8('isDischgPowerRateState ')   /* Choices DischgRateStates
+    .uint8('isDischgPowerRateState')   /* Choices DischgRateStates
             Off             = 0,
             Limited Power   = 2,
             Normal Power    = 4, */

--- a/payload/Msg_475a_StatusControlLogic.js
+++ b/payload/Msg_475a_StatusControlLogic.js
@@ -35,58 +35,58 @@ const status = new Parser()
 			Limited Power 	= 2,
 			Normal Power  	= 4, */
 	.uint8('isChargePowerRateCalc')  		/* Choices ChargeRateStates */
-	.uint8('hasChargeCellVoltHi ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeCellVoltPause ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeCellVoltLimPower ')  	// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeCellTempLo ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeCellTempHi ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeAmbientTempLo ') 		// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeAmbientTempHi ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeSupplyVoltHi ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeSupplyVoltPause ')  	// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeShuntVoltHi ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeShuntVoltPause ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeShuntVoltLimPower ')  	// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeShuntSocHi ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeShuntSocPause ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeAboveInitalBypass ')	// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeAboveFinalBypass ')		// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeInBypass ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeBypassComplete ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeBypassTempRelief ')  	// Boolean 0 = Off , 1 = On
-	.uint8('hasChargeBypassSessionLo ')  	// Boolean 0 = Off , 1 = On
-	.uint8('isDischgOnState ')  				// Boolean 0 = Off , 1 = On
-	.uint8('isDischgLimPower ')  			// Boolean 0 = Off , 1 = On
-	.uint8('isDischgTransition ')  			// Boolean 0 = Off , 1 = On
-	.uint8('isDischgPowerRateState ') /* Choices DischgRateStates
+	.uint8('hasChargeCellVoltHi')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeCellVoltPause')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeCellVoltLimPower')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeCellTempLo')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeCellTempHi')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeAmbientTempLo') 		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeAmbientTempHi')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeSupplyVoltHi')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeSupplyVoltPause')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntVoltHi')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntVoltPause')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntVoltLimPower')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntSocHi')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeShuntSocPause')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeAboveInitalBypass')	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeAboveFinalBypass')		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeInBypass')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeBypassComplete')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeBypassTempRelief')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasChargeBypassSessionLo')  	// Boolean 0 = Off , 1 = On
+	.uint8('isDischgOnState')  				// Boolean 0 = Off , 1 = On
+	.uint8('isDischgLimPower')  			// Boolean 0 = Off , 1 = On
+	.uint8('isDischgTransition')  			// Boolean 0 = Off , 1 = On
+	.uint8('isDischgPowerRateState') /* Choices DischgRateStates
 			Off 			= 0,
 			Limited Power 	= 2,
 			Normal Power  	= 4, */
-	.uint8('isDischgPowerRateCalc ')  		/* Choices DischgRateStates */
-	.uint8('hasDischgCellVoltLo ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgCellVoltPause ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgCellVoltLimPower ')  	// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgCellTempLo ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgCellTempHi ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgAmbientLo ')	  		// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgAmbientHi ') 			// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgSupplyVoltLo ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgSupplyVoltPause ')  	// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgShuntVoltLo ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgShuntVoltPause ')  		// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgShuntVoltLimPower ')  	// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgShuntSocLo ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasDischgShuntSocPause ')  		// Boolean 0 = Off , 1 = On
-	.uint8('isHeatOnState ')  				// Boolean 0 = Off , 1 = On
-	.uint8('isHeatOnCalc ')  				// Boolean 0 = Off , 1 = On
-	.uint8('isHeatTransition ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasHeatAmbientLo ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasHeatCellTempLo ')  			// Boolean 0 = Off , 1 = On
+	.uint8('isDischgPowerRateCalc')  		/* Choices DischgRateStates */
+	.uint8('hasDischgCellVoltLo')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgCellVoltPause')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgCellVoltLimPower')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgCellTempLo')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgCellTempHi')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgAmbientLo')	  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgAmbientHi') 			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgSupplyVoltLo')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgSupplyVoltPause')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntVoltLo')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntVoltPause')  		// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntVoltLimPower')  	// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntSocLo')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasDischgShuntSocPause')  		// Boolean 0 = Off , 1 = On
+	.uint8('isHeatOnState')  				// Boolean 0 = Off , 1 = On
+	.uint8('isHeatOnCalc')  				// Boolean 0 = Off , 1 = On
+	.uint8('isHeatTransition')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasHeatAmbientLo')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasHeatCellTempLo')  			// Boolean 0 = Off , 1 = On
 	.uint8('isCoolOnState')  				// Boolean 0 = Off , 1 = On
 	.uint8('isCoolOnCalc')  					// Boolean 0 = Off , 1 = On
 	.uint8('isCoolTransition')  				// Boolean 0 = Off , 1 = On
-	.uint8('hasCoolAmbientHi ')  			// Boolean 0 = Off , 1 = On
-	.uint8('hasCoolCellTempHi ')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasCoolAmbientHi')  			// Boolean 0 = Off , 1 = On
+	.uint8('hasCoolCellTempHi')  			// Boolean 0 = Off , 1 = On
 
 module.exports = function(msg)
 {


### PR DESCRIPTION
This PR removes trailing spaces from field names in the binary-parser definitions. Trailing spaces cause binary-parser to throw an 'Invalid field name' error, preventing the parsers from loading correctly in Node-RED.